### PR TITLE
Allow the Pointer to relocate relative to EOF

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -956,14 +956,14 @@ class Pointer(Subconstruct):
     def _parse(self, stream, context):
         newpos = self.offsetfunc(context)
         origpos = stream.tell()
-        stream.seek(newpos)
+        stream.seek(newpos, newpos < 0 and 2 or 0)
         obj = self.subcon._parse(stream, context)
         stream.seek(origpos)
         return obj
     def _build(self, obj, stream, context):
         newpos = self.offsetfunc(context)
         origpos = stream.tell()
-        stream.seek(newpos)
+        stream.seek(newpos, newpos < 0 and 2 or 0)
         self.subcon._build(obj, stream, context)
         stream.seek(origpos)
     def _sizeof(self, context):


### PR DESCRIPTION
Some binary file format have a fixed length
footer at the end of the file, which would
then contain the relative or absolute offsets
of other structures.

In order to parse the footer, the first thing
to do is to relocate at a position relative
to the end of the file, in order to read the
footer.

Without knowing the actual size of the file,
this is impossible to do if one can only move
to an absolute position from the beginning.

This change allow to specify a negative
position, which will be considered as starting
from the EOF (the same way as python array
indexes).
