### PR TITLE
Unicode Name Python 2.x Fix

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -3,6 +3,7 @@ from struct import Struct as Packer
 from construct.lib.py3compat import BytesIO, advance_iterator, bchr
 from construct.lib import Container, ListContainer, LazyContainer
 import sys
+import six
 
 try:
     bytes
@@ -99,7 +100,7 @@ class Construct(object):
     __slots__ = ["name", "conflags"]
     def __init__(self, name, flags = 0):
         if name is not None:
-            if type(name) is not str:
+            if not isinstance(name, six.string_types):
                 raise TypeError("name must be a string or None", name)
             if name == "_" or name.startswith("<"):
                 raise ValueError("reserved name", name)


### PR DESCRIPTION
Fix for issue #25. Now allows unicode names in Python 2, in addition to
binary string names. Python 3, as before, only allows unicode names.
Passes all tests (at least, those tests I could run) in Python 2.7 and Python 3.3.
