### PR TITLE
Fix FlagEnum print issue by using build-in getattr() function

### DIFF
--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -122,7 +122,7 @@ class FlagsContainer(Container):
         attrs = []
         ind = indentation * nesting
         for k in self.keys():
-            v = self.__dict__[k]
+            v = getattr(self, k)
             if not k.startswith("_") and v:
                 attrs.append(ind + k)
         if not attrs:


### PR DESCRIPTION
Using build-in getattr() seem to be able to avoid FlagEnum print issue.
