### PR TITLE
adds support of sizeof for PrefixedArray.

### DIFF
--- a/construct/macros.py
+++ b/construct/macros.py
@@ -263,10 +263,15 @@ def PrefixedArray(subcon, length_field = UBInt8("length")):
     :param subcon: the subcon to be repeated
     :param length_field: a construct returning an integer
     """
+    def _length(ctx):
+      if issubclass(ctx.__class__, (list, tuple)):
+        return len(ctx)
+      return ctx[length_field.name]
+
     return LengthValueAdapter(
         Sequence(subcon.name,
             length_field,
-            Array(lambda ctx: ctx[length_field.name], subcon),
+            Array(_length, subcon),
             nested = False
         )
     )

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -261,6 +261,7 @@ all_tests = [
 
     [PrefixedArray(UBInt8("array"), UBInt8("count")).parse, six.b("\x03\x01\x01\x01"), [1,1,1], None],
     [PrefixedArray(UBInt8("array"), UBInt8("count")).parse, six.b("\x03\x01\x01"), None, ArrayError],
+    [PrefixedArray(UBInt8("array"), UBInt8("count")).sizeof, [1,1,1], 4, None],
     [PrefixedArray(UBInt8("array"), UBInt8("count")).build, [1,1,1], six.b("\x03\x01\x01\x01"), None],
     
     [IfThenElse("ifthenelse", lambda ctx: True, UBInt8("then"), UBInt16("else")).parse, 


### PR DESCRIPTION
PrefixedArray raises an exeption when sizeof is called with its return value as context (which works for most of objects).

Although sizeof is not that important on a built object, i find it quite usefull for space consideration before calling the build method or after parse (paticularilly when the objects do not set the stream pointer properly after being processed).

The problem is added as a test.

The proposed fix is not the prettiest one but adding an module-global function did not seem better and covers most usecases (assuming the user will not provide a build object created from a list-like object that is not a list or a tuple child.).
