### PR TITLE
Added support for building wheels packaging format.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,3 +3,5 @@ python setup.py register
 python setup.py sdist --formats=zip,gztar upload
 python setup.py bdist_wininst --plat-name=win32 upload
 
+# Make sure you have 'wheel' installed: pip install wheel
+python setup.py bdist_wheel upload 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
When running build.sh, make sure to have wheels installed: pip install wheel
Information: http://pythonwheels.com/
PEP (accepted): http://legacy.python.org/dev/peps/pep-0427/
