### PR TITLE
Subclass Containers using the names of Structs and Sequences.

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -644,7 +644,7 @@ class Struct(Construct):
             UBInt8("third_element"),
         )
     """
-    __slots__ = ["subcons", "nested", "allow_overwrite"]
+    __slots__ = ["subcons", "nested", "allow_overwrite", "container"]
     def __init__(self, name, *subcons, **kw):
         self.nested = kw.pop("nested", True)
         self.allow_overwrite = kw.pop("allow_overwrite", False)
@@ -720,7 +720,7 @@ class Sequence(Struct):
             UBInt8("third_element"),
         )
     """
-    __slots__ = []
+    __slots__ = ["list_container"]
     def __init__(self, name, *subcons, **kw):
         Struct.__init__(name, *subcons, **kw)
         if self.name is not None:

--- a/construct/core.py
+++ b/construct/core.py
@@ -722,7 +722,7 @@ class Sequence(Struct):
     """
     __slots__ = ["list_container"]
     def __init__(self, name, *subcons, **kw):
-        Struct.__init__(name, *subcons, **kw)
+        Struct.__init__(self, name, *subcons, **kw)
         if self.name is not None:
             self.list_container = type(self.name, (ListContainer,), {})
         else:


### PR DESCRIPTION
I can't claim credit for the original idea, which came from Nathan Ramella on the discussion group: https://groups.google.com/forum/#!topic/construct3/SbI5SXsJ7Rw .  I moved the creation of the Container subclass to `__init__` and added the same functionality to Sequence, only with ListContainer.  The main purpose for which I want this functionality is for type dispatch in a visitor pattern.

Note that the odd situation where two classes share the same name is possible if two Structs share the same name.  Python doesn't care fundamentally, but it can be confusing for humans reading the code:

````
Python 3.4.0 (default, Apr 11 2014, 13:05:11) 
[GCC 4.8.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...   pass
... 
>>> A1 = A
>>> class A:
...   pass
... 
>>> A2 = A
>>> A1 is A2
False
>>> a1 = A1()
>>> a2 = A()
>>> isinstance(a1, A)
False
>>> isinstance(a2, A)
True
>>> type(a1)
<class '__main__.A'>
>>> type(a2)
<class '__main__.A'>
````

This could be changed with a registry attached to the class but that creates the possibility of Structs that have different submembers sharing the same Container subclass.