### PR TITLE
Automatically calculate Value in Struct

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -686,7 +686,11 @@ class Struct(Construct):
             elif sc.name is None:
                 subobj = None
             else:
-                subobj = getattr(obj, sc.name)
+                if isinstance(sc, Value):
+                    # allow automatic value calculation from passed obj during build
+                    subobj = obj
+                else:
+                    subobj = getattr(obj, sc.name)
                 context[sc.name] = subobj
             sc._build(subobj, stream, context)
     def _sizeof(self, context):


### PR DESCRIPTION
When building Struct containing Value it's needed to pass the Value
explicitly. That's not symmetrical to parsing the same structure data,
when the Value is calculated automatically.
This change checks for Value in Struct subcons and if detected, just
passes the object, allowing the Value to be automatically calculated.