### PR TITLE
fix ConstError in the formats/graphics/png.py example.

### DIFF
--- a/construct/formats/graphics/png.py
+++ b/construct/formats/graphics/png.py
@@ -318,7 +318,7 @@ chunk = Struct("chunk",
 
 image_header_chunk = Struct("image_header",
     UBInt32("length"),
-    Const(String("type", 4), "IHDR"),
+    Const(String("type", 4, "utf-8"), "IHDR"),
     UBInt32("width"),
     UBInt32("height"),
     UBInt8("bit_depth"),


### PR DESCRIPTION
or else you get (or I did when running on python3.5): `construct.adapters.ConstError: expected 'IHDR', found b'IHDR'`
