### PR TITLE
Only call `__pretty_str__` if it's bound to an instance.

### DIFF
--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -97,7 +97,7 @@ class Container(dict):
         for k, v in self.iteritems():
             if not k.startswith("_"):
                 text = [ind, k, " = "]
-                if hasattr(v, "__pretty_str__"):
+                if hasattr(type(v), "__pretty_str__"):
                     text.append(v.__pretty_str__(nesting + 1, indentation))
                 else:
                     text.append(repr(v))
@@ -149,7 +149,7 @@ class ListContainer(list):
         for elem in self:
             lines.append("\n")
             lines.append(ind)
-            if hasattr(elem, "__pretty_str__"):
+            if hasattr(type(elem), "__pretty_str__"):
                 lines.append(elem.__pretty_str__(nesting + 1, indentation))
             else:
                 lines.append(repr(elem))
@@ -185,7 +185,7 @@ class LazyContainer(object):
     def __pretty_str__(self, nesting = 1, indentation = "    "):
         if self._value is NotImplemented:
             text = "<unread>"
-        elif hasattr(self._value, "__pretty_str__"):
+        elif hasattr(type(self._value), "__pretty_str__"):
             text = self._value.__pretty_str__(nesting, indentation)
         else:
             text = str(self._value)


### PR DESCRIPTION
Sometimes, a Container class object (not instance) can end up in a Container.
Calling `__pretty_str__` on it will fail as it's not a bound method.

This was discovered using IPython and the Probe() construct.
In that case, the stack frames and local variables are stored in a Container
and because IPython pollutes the stack, we get a Container class object in
a Container.

The problem can be reproduced without IPython:
```
def foo():
    var = Container
    Probe().build(None)
foo()
```

Or more easily:
```
print(Container(c=Container))
```

The fix consists of testing `__pretty_str__` on the type() of the variable
rather than on the variable itself.

The only drawback that I can think of happens when a class defines a
`__pretty_str__` method by directly assigning it to the instance, eg:
```self.__pretty_str__ = lambda self: ...```

In that case it would not be detected and `__repr__` would be used instead.

I considered another fix involving testing the `__self__` / `im_self` attribute
to determine if the method was bound, but the `this` object (expr.py)
always returned an object for `__self__` (as well as `__pretty_str__` !)