### PR TITLE
Allow constructing binary streams from dicts.

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -686,7 +686,11 @@ class Struct(Construct):
             elif sc.name is None:
                 subobj = None
             else:
-                subobj = getattr(obj, sc.name)
+                if isinstance(obj, dict):
+                    subobj = obj[sc.name]
+                else:
+                    subobj = getattr(obj, sc.name)
+                    
                 context[sc.name] = subobj
             sc._build(subobj, stream, context)
     def _sizeof(self, context):


### PR DESCRIPTION
Basically, right now, you cannot serialize a set of nested dictionaries representing your structure to a bytestream, because `getattr()` only works on objects.

This very simple patch checks if an item is a dictionary, and if it is it retrieves the contained item by key, rather then attribute.

