### PR TITLE
Fix the use of Peek in a Prefixed Subconstruct

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -688,7 +688,7 @@ class TestCore(unittest.TestCase):
         assert Prefixed(VarInt, GreedyBytes).parse(b"\x03abcgarbage") == b"abc"
         assert Prefixed(VarInt, GreedyBytes).build(b"abc") == b'\x03abc'
         assert Prefixed(Byte, Int64ub).sizeof() == 9
-        assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub)).parse(b"\x02\x00\xffgarbage") == [0,255]
+        assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub, GreedyBytes)).parse(b"\x02\x00\xffgarbage") == [0,255,'']
         assert raises(Prefixed(VarInt, GreedyBytes).sizeof) == SizeofError
 
     def test_compressed_zlib(self):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -688,6 +688,7 @@ class TestCore(unittest.TestCase):
         assert Prefixed(VarInt, GreedyBytes).parse(b"\x03abcgarbage") == b"abc"
         assert Prefixed(VarInt, GreedyBytes).build(b"abc") == b'\x03abc'
         assert Prefixed(Byte, Int64ub).sizeof() == 9
+        assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub)).parse(b"\x02\x00\xffgarbage") == [0,255]
         assert raises(Prefixed(VarInt, GreedyBytes).sizeof) == SizeofError
 
     def test_compressed_zlib(self):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -688,7 +688,7 @@ class TestCore(unittest.TestCase):
         assert Prefixed(VarInt, GreedyBytes).parse(b"\x03abcgarbage") == b"abc"
         assert Prefixed(VarInt, GreedyBytes).build(b"abc") == b'\x03abc'
         assert Prefixed(Byte, Int64ub).sizeof() == 9
-        assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub, GreedyBytes)).parse(b"\x02\x00\xffgarbage") == [0,255,'']
+        assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub, GreedyBytes)).parse(b"\x02\x00\xffgarbage") == [0,255,b'']
         assert raises(Prefixed(VarInt, GreedyBytes).sizeof) == SizeofError
 
     def test_compressed_zlib(self):


### PR DESCRIPTION
Prior to 3cb79d89a61510dd8d63816bb32380e7e1a2b1c9 it was possible to use `Peek` in the subconstruct of `Prefixed`, however with the introduction of `BoundBytesIO` using `Peek` will generate an exception
```python
AttributeError: BoundBytesIO instance has no attribute 'seek'
```
This PR adds the seek functionality to `BoundBytesIO` and re-enables the use of `Peek` in a prefixed `Subconstruct`.