### PR TITLE
Fix pickling

### DIFF
--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -60,7 +60,8 @@ class Container(dict):
         return list(self.items())
 
     def __setstate__(self, state):
-        self.__init__(state)
+        object.__setattr__(self, "__keys_order__", [])
+        dict.clear(self)
         self.update(state)
 
     def __getattr__(self, name):

--- a/tests/lib/test_container.py
+++ b/tests/lib/test_container.py
@@ -31,7 +31,7 @@ class TestContainer(unittest.TestCase):
     @pytest.mark.xfail(reason="pickling code is wrong?")
     def test_pickling(self):
         import pickle
-        c = Container(a=1)(b=2)(c=3)(d=4)
+        c = Container(a=1)(b=2)(c=3)(d=Container(e=4))
         d = pickle.loads(pickle.dumps(c))
         assert c == d
 


### PR DESCRIPTION
Reset explicitly all state-related variables and apply the supplied state.
Also add an inner Container to the pickling test.

This should fix #249.