### PR TITLE
Bug fix for Debugger, fixes NameError

### DIFF
--- a/construct/debug.py
+++ b/construct/debug.py
@@ -226,7 +226,7 @@ class Debugger(Subconstruct):
             return self.subcon._parse(stream, context, path)
         except Exception:
             self.retval = NotImplemented
-            self.handle_exc("(you can set the value of 'self.retval', which will be returned)")
+            self.handle_exc(path, msg="(you can set the value of 'self.retval', which will be returned)")
             if self.retval is NotImplemented:
                 raise
             else:
@@ -236,15 +236,15 @@ class Debugger(Subconstruct):
         try:
             self.subcon._build(obj, stream, context, path)
         except Exception:
-            self.handle_exc()
+            self.handle_exc(path)
 
     def _sizeof(self, context, path):
         try:
             self.subcon._sizeof(context, path)
         except Exception:
-            self.handle_exc()
+            self.handle_exc(path)
 
-    def handle_exc(self, msg = None):
+    def handle_exc(self, path, msg=None):
         print("================================================================================")
         print("Debugging exception of %s:" % self.subcon)
         print("path is %s" % path)


### PR DESCRIPTION
Running the manual debugger test gives the following output
```
python tests/manual_debug.py
Container:
    bar = 1
    spam = DEF
    eggs = 3
================================================================================
Debugging exception of <Renamed: spam>:
Traceback (most recent call last):
  File "/home/beardypig/construct/construct/core.py", line 2768, in _decode
    return self.decoding[obj]
KeyError: 4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/beardypig/construct/construct/core.py", line 2696, in _parse
    return self.subcon._parse(stream, context, path)
  File "/home/beardypig/construct/construct/core.py", line 313, in _parse
    return self._decode(self.subcon._parse(stream, context, path), context)
  File "/home/beardypig/construct/construct/core.py", line 2773, in _decode
    raise MappingError("no decoding mapping for %r" % (obj,))
construct.core.MappingError: no decoding mapping for 4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/beardypig/construct/construct/debug.py", line 226, in _parse
    return self.subcon._parse(stream, context, path)
  File "/home/beardypig/construct/construct/core.py", line 2700, in _parse
    raise e.__class__("%s\n    %s" % (e, path))
construct.core.MappingError: no decoding mapping for 4
    parsing -> spam

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/manual_debug.py", line 16, in <module>
    print(foo.parse(b"\x01\x04\x03"))
  File "/home/beardypig/construct/construct/core.py", line 175, in parse
    return self.parse_stream(BytesIO(data), context, **kw)
  File "/home/beardypig/construct/construct/core.py", line 186, in parse_stream
    return self._parse(stream, context, "parsing")
  File "/home/beardypig/construct/construct/core.py", line 859, in _parse
    subobj = sc._parse(stream, context, path)
  File "/home/beardypig/construct/construct/debug.py", line 229, in _parse
    self.handle_exc("(you can set the value of 'self.retval', which will be returned)")
  File "/home/beardypig/construct/construct/debug.py", line 250, in handle_exc
    print("path is %s" % path)
NameError: name 'path' is not defined
```

This PR proposes a fix for that error. 