### PR TITLE
Fix pickling in Python 2 and 3

### DIFF
--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -110,7 +110,7 @@ class Container(dict):
             dict.__setitem__(self, key, val)
 
     def __delitem__(self, key):
-        '''Removes a slot or an item from a Container in non-constant time.'''
+        """Removes an item from the Container in linear time O(n)."""
         if key in self.__slots__:
             object.__delattr__(self, key)
         else:

--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -110,6 +110,7 @@ class Container(dict):
             dict.__setitem__(self, key, val)
 
     def __delitem__(self, key):
+        '''Removes a slot or an item from a Container in non-constant time.'''
         if key in self.__slots__:
             object.__delattr__(self, key)
         else:

--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -58,7 +58,7 @@ class Container(dict):
 
         Container(container2)
     """
-    __slots__ = ["__keys_order__","__recursion_lock__"]
+    __slots__ = ["__keys_order__", "__recursion_lock__"]
 
     def __init__(self, *args, **kw):
         object.__setattr__(self, "__keys_order__", [])
@@ -77,27 +77,44 @@ class Container(dict):
             self[k] = v
 
     def __getstate__(self):
-        return list(self.items())
+        return self.__keys_order__
 
     def __setstate__(self, state):
-        object.__setattr__(self, "__keys_order__", [])
-        dict.clear(self)
-        self.update(state)
+        self.__keys_order__ = state
 
     def __getattr__(self, name):
         try:
-            return self[name]
+            if name in self.__slots__:
+                try:
+                    return object.__getattribute__(self, name)
+                except AttributeError as e:
+                    if name == "__keys_order__":
+                        object.__setattr__(self, "__keys_order__", [])
+                        return []
+                    else:
+                        raise e
+            else:
+                return self[name]
         except KeyError:
             raise AttributeError(name)
 
     def __setitem__(self, key, val):
-        if key not in self:
-            self.__keys_order__.append(key)
-        dict.__setitem__(self, key, val)
+        if key in self.__slots__:
+            object.__setattr__(self, key, val)
+        else:
+            if key not in self:
+                if not hasattr(self, "__keys_order__"):
+                    object.__setattr__(self, "__keys_order__", [key])
+                else:
+                    self.__keys_order__.append(key)
+            dict.__setitem__(self, key, val)
 
     def __delitem__(self, key):
-        dict.__delitem__(self, key)
-        self.__keys_order__.remove(key)
+        if key in self.__slots__:
+            object.__delattr__(self, key)
+        else:
+            dict.__delitem__(self, key)
+            self.__keys_order__.remove(key)
 
     __delattr__ = __delitem__
     __setattr__ = __setitem__

--- a/tests/lib/test_container.py
+++ b/tests/lib/test_container.py
@@ -28,12 +28,16 @@ class TestContainer(unittest.TestCase):
         assert c == d
         assert list(c.items()) == list(d.items())
 
-    @pytest.mark.xfail(reason="pickling code is wrong?")
     def test_pickling(self):
         import pickle
-        c = Container(a=1)(b=2)(c=3)(d=Container(e=4))
-        d = pickle.loads(pickle.dumps(c))
-        assert c == d
+
+        empty = Container()
+        empty_unpickled = pickle.loads(pickle.dumps(empty))
+        assert empty_unpickled == empty
+
+        embedded = Container(a=1)(b=Container())(c=3)(d=Container(e=4))
+        embedded_unpickled = pickle.loads(pickle.dumps(embedded))
+        assert embedded_unpickled == embedded
 
     def test_getitem(self):
         c = Container(a=1)

--- a/tests/lib/test_container.py
+++ b/tests/lib/test_container.py
@@ -35,9 +35,9 @@ class TestContainer(unittest.TestCase):
         empty_unpickled = pickle.loads(pickle.dumps(empty))
         assert empty_unpickled == empty
 
-        embedded = Container(a=1)(b=Container())(c=3)(d=Container(e=4))
-        embedded_unpickled = pickle.loads(pickle.dumps(embedded))
-        assert embedded_unpickled == embedded
+        nested = Container(a=1)(b=Container())(c=3)(d=Container(e=4))
+        nested_unpickled = pickle.loads(pickle.dumps(nested))
+        assert nested_unpickled == nested
 
     def test_getitem(self):
         c = Container(a=1)


### PR DESCRIPTION
Explicitly use `object` or `dict` methods for getting attributes. This keeps
the `__slots__` as `object` attributes and everything else as part of the
`dict` instance.

Pickle can then automatically takes care of the `dict` and the only
relevant slot (`__keys_order__`) is saved. No need to update a
dictionary with the items it already has.

This should address at least the pickling part of #249 .

I've removed the expected fail from the test suite. This should pass for all supported Python versions before being merged.