### PR TITLE
Don't hide Exceptions in Range._build

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1021,6 +1021,8 @@ class Range(Subconstruct):
         except Exception:
             if len(obj) < min:
                 raise RangeError("expected %d to %d, found %d" % (min, max, len(obj)))
+            else:
+                raise
     def _sizeof(self, context, path):
         try:
             min = self.min(context) if callable(self.min) else self.min

--- a/construct/examples/formats/data/cap.py
+++ b/construct/examples/formats/data/cap.py
@@ -10,7 +10,7 @@ class MicrosecAdapter(Adapter):
         return datetime.datetime.fromtimestamp(obj[0] + obj[1] / 1000000.0)
     def _encode(self, obj, context):
         epoch = datetime.datetime.utcfromtimestamp(0)
-        return [(obj - epoch).total_seconds(), 0]
+        return [int((obj - epoch).total_seconds()), 0]
 
         # offset = time.mktime(*obj.timetuple())
         # sec = int(offset)


### PR DESCRIPTION
Exceptions are hidden when building a Range object. I was having some problems debugging until I worked it out :)