### PR TITLE
Add __getitem__ to Path for the this expression.

### DIFF
--- a/construct/expr.py
+++ b/construct/expr.py
@@ -146,6 +146,8 @@ class Path(ExprMixin):
         return context2[self.__name]
     def __getattr__(self, name):
         return Path(name, self)
+    def __getitem__(self, name):
+    	return Path(name, self)
 
 this = Path("this")
 

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -62,17 +62,19 @@ Container(length1=49)(inner=Container(length2=50)(sum=99))
 Using `this` expression
 ===========================
 
-Certain classes take a number of elements, or something similar, and allow a callable to be provided instead. This callable is called at parsing and building, and is provided the current context object. Context is always a Container, not a dict, so it supports attribute as well as key access. Amazingly, this can get even more fancy. Tomer Filiba provided even a better syntax. The `this` singleton object can be used to build a lambda expression. All three examples below are equivalent:
+Certain classes take a number of elements, or something similar, and allow a callable to be provided instead. This callable is called at parsing and building, and is provided the current context object. Context is always a Container, not a dict, so it supports attribute as well as key access. Amazingly, this can get even more fancy. Tomer Filiba provided even a better syntax. The `this` singleton object can be used to build a lambda expression. All four examples below are equivalent:
 
 >>> lambda ctx: ctx["_"]["field"]
 ...
 >>> lambda ctx: ctx._.field
 ...
 >>> this._.field
+...
+>>> this._["field"]
 
 Of course, `this` can be mixed with other calculations. When evaluating, each instance of this is replaced by ctx.
 
->>> this.width * this.height - this.offset
+>>> this.width * this.height - this["offset"]
 
 
 

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -70,11 +70,11 @@ Certain classes take a number of elements, or something similar, and allow a cal
 ...
 >>> this._.field
 ...
->>> this._["field"]
+>>> this["_"]["field"]
 
 Of course, `this` can be mixed with other calculations. When evaluating, each instance of this is replaced by ctx.
 
->>> this.width * this.height - this["offset"]
+>>> this.width * this.height - this.offset
 
 
 

--- a/tests/test_this.py
+++ b/tests/test_this.py
@@ -31,6 +31,14 @@ class TestThis(unittest.TestCase):
         assert this_example.parse(b"\x05helloABXXXX") == Container(length=5)(value=b'hello')(nested=Container(b1=65)(b2=66)(b3=4295))(condition=1482184792)
         assert this_example.build(dict(length=5, value=b'hello', nested=dict(b1=65, b2=66), condition=1482184792)) == b"\x05helloABXXXX"
 
+    def test_this_getitem(self):
+        gi = Struct(
+            "length of text" / Int8ub,
+            "text" / Bytes(this["length of text"]),
+        )
+        assert gi.parse(b"\x06World!") == Container({"length of text": 6, "text":b"World!"})
+        assert gi.build({"length of text": 6, "text":b"World!"}) == b"\x06World!"
+
     def test_path(self):
         path = Path("path")
         x = ~((path.foo * 2 + 3 << 2) % 11)


### PR DESCRIPTION
This enables the use of [] to get items from this.

e.g.
```this["item with space and punctuation in it's name!"]```

Closes #276