### PR TITLE
Make `RepeatUntil` take in-progress `Container`

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -9,6 +9,7 @@ import sys
 import collections
 
 from construct.lib import *
+from construct.expr import ExprMixin
 
 
 #===============================================================================
@@ -1135,7 +1136,9 @@ class RepeatUntil(Subconstruct):
             while True:
                 subobj = self.subcon._parse(stream, context, path)
                 obj.append(subobj)
-                if self.predicate(obj, context):
+                # TODO: Get rid of this when rethinking obj_, this
+                args = (subobj, context) if self.predicate is ExprMixin else (subobj, context, obj)
+                if self.predicate(*args):
                     return obj
         except ExplicitError:
             raise
@@ -1144,7 +1147,9 @@ class RepeatUntil(Subconstruct):
     def _build(self, obj, stream, context, path):
         for subobj in obj:
             self.subcon._build(subobj, stream, context, path)
-            if self.predicate(subobj, context):
+            # TODO: Get rid of this when rethinking obj_, this
+            args = (subobj, context) if self.predicate is ExprMixin else (subobj, context, obj)
+            if self.predicate(*args):
                 break
         else:
             raise RangeError("missing terminator when building")

--- a/construct/core.py
+++ b/construct/core.py
@@ -1113,16 +1113,16 @@ class PrefixedArray(Construct):
 
 class RepeatUntil(Subconstruct):
     r"""
-    An array that repeats until the predicate indicates it to stop. Note that the last element (which caused the repeat to exit) is included in the return value.
+    An array that repeats until the predicate indicates it to stop. Note that the last element (in which the `predicate` is `True`) is included in the return value.
 
     :param predicate: a predicate function that takes (obj, context) and returns True to break, or False to continue
     :param subcon: the subcon used to parse and build each element
 
     Example::
 
-        >>> RepeatUntil(lambda x,ctx: x>7, Byte).build(range(20))
+        >>> RepeatUntil(lambda x,ctx: x[-1]>7, Byte).build(range(20))
         b'\x00\x01\x02\x03\x04\x05\x06\x07\x08'
-        >>> RepeatUntil(lambda x,ctx: x>7, Byte).parse(b"\x01\xff\x02")
+        >>> RepeatUntil(lambda x,ctx: x[-1]>7, Byte).parse(b"\x01\xff\x02")
         [1, 255]
     """
     __slots__ = ["predicate"]
@@ -1135,7 +1135,7 @@ class RepeatUntil(Subconstruct):
             while True:
                 subobj = self.subcon._parse(stream, context, path)
                 obj.append(subobj)
-                if self.predicate(subobj, context):
+                if self.predicate(obj, context):
                     return obj
         except ExplicitError:
             raise

--- a/construct/core.py
+++ b/construct/core.py
@@ -1130,11 +1130,13 @@ class RepeatUntil(Subconstruct):
         >>> # Parse bytes until five even ones have appeared
         >>> RepeatUntil(lambda x,lst,ctx: sum(map(lambda e: e % 2 == 0, lst)) > 5, Byte).parse(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09")
         [0, 1, 2, 3, 4, 5, 6, 7, 8]
-        >>> # Parse until the sequence is a palindrome of at least seven Bytes.
-        >>> RepeatUntil(lambda x,lst,ctx: (lst[::-1] == lst) and (len(lst) >= 7), Byte).parse(b"\x01\x02\x03\x04\x03\x02\x01\x00")
+        >>> # Parse until the sequence is a palindrome of at least three Bytes.
+        >>> 3pal = cs.RepeatUntil(lambda x,xs,ctx: (xs[::-1] == xs) and (len(xs) > 3), cs.Byte)
+        >>> 3pal.parse(b'\x01\x02\x03\x04\x03\x02\x01\x00')
         [1, 2, 3, 4, 3, 2, 1]
-        >>> RepeatUntil(lambda x,lst,ctx: (lst[::-1] == lst) and (len(lst) >= 7), Byte).build(_)
-        b'\x01\x02\x03\x04\x03\x02\x01\x00'
+        >>> 3pal.build(_)
+        '\x01\x02\x03\x04\x03\x02\x01'
+
     """
     __slots__ = ["predicate"]
     def __init__(self, predicate, subcon):

--- a/construct/core.py
+++ b/construct/core.py
@@ -1116,14 +1116,16 @@ class RepeatUntil(Subconstruct):
     r"""
     An array that repeats until the predicate indicates it to stop. Note that the last element (in which the `predicate` is `True`) is included in the return value.
 
-    :param predicate: a predicate function that takes (obj, context) and returns True to break, or False to continue
+    :param predicate: a predicate function that takes (obj, context, current_list) and returns True to break, or False to continue
     :param subcon: the subcon used to parse and build each element
 
     Example::
 
-        >>> RepeatUntil(lambda x,ctx: x[-1]>7, Byte).build(range(20))
+        >>> RepeatUntil(lambda x,ctx,lst: x[-1]>7, Byte).build(range(20))
         b'\x00\x01\x02\x03\x04\x05\x06\x07\x08'
-        >>> RepeatUntil(lambda x,ctx: x[-1]>7, Byte).parse(b"\x01\xff\x02")
+        >>> RepeatUntil(lambda x,ctx,lst: x[-1]>7, Byte).parse(b"\x01\xff\x02")
+        [1, 255]
+        >>> RepeatUntil(lambda x,ctx,lst: len(lst)==2, Byte).parse(b"\x01\xff\x02")
         [1, 255]
     """
     __slots__ = ["predicate"]
@@ -1819,7 +1821,7 @@ class Rebuffered(Subconstruct):
 
     Example::
 
-        Rebuffered(RepeatUntil(lambda obj,ctx: ?,Byte), tailcutoff=1024).parse_stream(endless_nonblocking_stream)
+        Rebuffered(RepeatUntil(lambda obj,ctx,lst: ?,Byte), tailcutoff=1024).parse_stream(endless_nonblocking_stream)
     """
     __slots__ = ["stream2", "tailcutoff"]
     def __init__(self, subcon, tailcutoff=None):
@@ -3379,7 +3381,7 @@ def CString(terminators=b"\x00", encoding=None):
     """
     return StringEncoded(
         ExprAdapter(
-            RepeatUntil(lambda obj,ctx: int2byte(obj) in terminators, Byte),
+            RepeatUntil(lambda obj,ctx,lst: int2byte(obj) in terminators, Byte),
             encoder = lambda obj,ctx: iterateints(obj+terminators),
             decoder = lambda obj,ctx: b''.join(int2byte(c) for c in obj[:-1])),
         encoding)

--- a/construct/core.py
+++ b/construct/core.py
@@ -1127,6 +1127,12 @@ class RepeatUntil(Subconstruct):
         [1, 255]
         >>> RepeatUntil(lambda x,lst,ctx: len(lst)==2, Byte).parse(b"\x01\xff\x02")
         [1, 255]
+        >>> # Parse bytes until five even ones have appeared
+        >>> RepeatUntil(lambda x,lst,ctx: sum(map(lambda e: e % 2 == 0, lst)) > 5, Byte).parse(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09")
+        [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        >>> # Parse Bytes until the sequence is a palindrome
+        >>> RepeatUntil(lambda x,lst,ctx: lst[::-1] == lst, Byte).parse(b"\x01\x02\x03\x04\x03\x02\x01\x00")
+        [1, 2, 3, 4, 3, 2, 1]
     """
     __slots__ = ["predicate"]
     def __init__(self, predicate, subcon):

--- a/construct/core.py
+++ b/construct/core.py
@@ -1153,10 +1153,10 @@ class RepeatUntil(Subconstruct):
         except ConstructError:
             raise RangeError("missing terminator when parsing")
     def _build(self, obj, stream, context, path):
-        for subobj in obj:
+        for i, subobj in enumerate(obj):
             self.subcon._build(subobj, stream, context, path)
             # TODO: Get rid of this when rethinking obj_, this
-            args = (subobj, context) if self.predicate is ExprMixin else (subobj, obj, context)
+            args = (subobj, context) if self.predicate is ExprMixin else (subobj, obj[:i+1], context)
             if self.predicate(*args):
                 break
         else:

--- a/construct/core.py
+++ b/construct/core.py
@@ -1121,9 +1121,9 @@ class RepeatUntil(Subconstruct):
 
     Example::
 
-        >>> RepeatUntil(lambda x,lst,ctx: x[-1]>7, Byte).build(range(20))
+        >>> RepeatUntil(lambda x,lst,ctx: x>7, Byte).build(range(20))
         b'\x00\x01\x02\x03\x04\x05\x06\x07\x08'
-        >>> RepeatUntil(lambda x,lst,ctx: x[-1]>7, Byte).parse(b"\x01\xff\x02")
+        >>> RepeatUntil(lambda x,lst,ctx: x>7, Byte).parse(b"\x01\xff\x02")
         [1, 255]
         >>> RepeatUntil(lambda x,lst,ctx: len(lst)==2, Byte).parse(b"\x01\xff\x02")
         [1, 255]

--- a/construct/core.py
+++ b/construct/core.py
@@ -1130,9 +1130,11 @@ class RepeatUntil(Subconstruct):
         >>> # Parse bytes until five even ones have appeared
         >>> RepeatUntil(lambda x,lst,ctx: sum(map(lambda e: e % 2 == 0, lst)) > 5, Byte).parse(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09")
         [0, 1, 2, 3, 4, 5, 6, 7, 8]
-        >>> # Parse Bytes until the sequence is a palindrome
-        >>> RepeatUntil(lambda x,lst,ctx: lst[::-1] == lst, Byte).parse(b"\x01\x02\x03\x04\x03\x02\x01\x00")
+        >>> # Parse until the sequence is a palindrome of at least seven Bytes.
+        >>> RepeatUntil(lambda x,lst,ctx: (lst[::-1] == lst) and (len(lst) >= 7), Byte).parse(b"\x01\x02\x03\x04\x03\x02\x01\x00")
         [1, 2, 3, 4, 3, 2, 1]
+        >>> RepeatUntil(lambda x,lst,ctx: (lst[::-1] == lst) and (len(lst) >= 7), Byte).build(_)
+        b'\x01\x02\x03\x04\x03\x02\x01\x00'
     """
     __slots__ = ["predicate"]
     def __init__(self, predicate, subcon):

--- a/construct/core.py
+++ b/construct/core.py
@@ -1116,16 +1116,16 @@ class RepeatUntil(Subconstruct):
     r"""
     An array that repeats until the predicate indicates it to stop. Note that the last element (in which the `predicate` is `True`) is included in the return value.
 
-    :param predicate: a predicate function that takes (obj, context, current_list) and returns True to break, or False to continue
+    :param predicate: a predicate function that takes (obj, current_list, context) and returns True to break, or False to continue
     :param subcon: the subcon used to parse and build each element
 
     Example::
 
-        >>> RepeatUntil(lambda x,ctx,lst: x[-1]>7, Byte).build(range(20))
+        >>> RepeatUntil(lambda x,lst,ctx: x[-1]>7, Byte).build(range(20))
         b'\x00\x01\x02\x03\x04\x05\x06\x07\x08'
-        >>> RepeatUntil(lambda x,ctx,lst: x[-1]>7, Byte).parse(b"\x01\xff\x02")
+        >>> RepeatUntil(lambda x,lst,ctx: x[-1]>7, Byte).parse(b"\x01\xff\x02")
         [1, 255]
-        >>> RepeatUntil(lambda x,ctx,lst: len(lst)==2, Byte).parse(b"\x01\xff\x02")
+        >>> RepeatUntil(lambda x,lst,ctx: len(lst)==2, Byte).parse(b"\x01\xff\x02")
         [1, 255]
     """
     __slots__ = ["predicate"]
@@ -1139,7 +1139,7 @@ class RepeatUntil(Subconstruct):
                 subobj = self.subcon._parse(stream, context, path)
                 obj.append(subobj)
                 # TODO: Get rid of this when rethinking obj_, this
-                args = (subobj, context) if self.predicate is ExprMixin else (subobj, context, obj)
+                args = (subobj, context) if self.predicate is ExprMixin else (subobj, obj, context)
                 if self.predicate(*args):
                     return obj
         except ExplicitError:
@@ -1150,7 +1150,7 @@ class RepeatUntil(Subconstruct):
         for subobj in obj:
             self.subcon._build(subobj, stream, context, path)
             # TODO: Get rid of this when rethinking obj_, this
-            args = (subobj, context) if self.predicate is ExprMixin else (subobj, context, obj)
+            args = (subobj, context) if self.predicate is ExprMixin else (subobj, obj, context)
             if self.predicate(*args):
                 break
         else:
@@ -1821,7 +1821,7 @@ class Rebuffered(Subconstruct):
 
     Example::
 
-        Rebuffered(RepeatUntil(lambda obj,ctx,lst: ?,Byte), tailcutoff=1024).parse_stream(endless_nonblocking_stream)
+        Rebuffered(RepeatUntil(lambda obj,lst,ctx: ?,Byte), tailcutoff=1024).parse_stream(endless_nonblocking_stream)
     """
     __slots__ = ["stream2", "tailcutoff"]
     def __init__(self, subcon, tailcutoff=None):
@@ -3381,7 +3381,7 @@ def CString(terminators=b"\x00", encoding=None):
     """
     return StringEncoded(
         ExprAdapter(
-            RepeatUntil(lambda obj,ctx,lst: int2byte(obj) in terminators, Byte),
+            RepeatUntil(lambda obj,lst,ctx: int2byte(obj) in terminators, Byte),
             encoder = lambda obj,ctx: iterateints(obj+terminators),
             decoder = lambda obj,ctx: b''.join(int2byte(c) for c in obj[:-1])),
         encoding)

--- a/construct/examples/formats/graphics/gif.py
+++ b/construct/examples/formats/graphics/gif.py
@@ -125,7 +125,7 @@ image_descriptor = Struct("image_descriptor",
         )
     ),
     ULInt8("LZW_minimum_code_size"),
-    RepeatUntil(lambda obj, ctx, lst: obj.size == 0, data_sub_block)
+    RepeatUntil(lambda obj, lst, ctx: obj.size == 0, data_sub_block)
 )
 
 gif_data = Struct("gif_data",

--- a/construct/examples/formats/graphics/gif.py
+++ b/construct/examples/formats/graphics/gif.py
@@ -125,7 +125,7 @@ image_descriptor = Struct("image_descriptor",
         )
     ),
     ULInt8("LZW_minimum_code_size"),
-    RepeatUntil(lambda obj, ctx: obj.size == 0, data_sub_block)
+    RepeatUntil(lambda obj, ctx, lst: obj.size == 0, data_sub_block)
 )
 
 gif_data = Struct("gif_data",

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -268,10 +268,7 @@ GreedyRange is essentially a Range from 0 to infinity.
 
 RepeatUntil is different than the others. Each element is tested by a lambda predicate. The predicate signals when a given element is the terminal element. The repeater inserts all previous items along with the terminal one, and returns just the same.
 
->>> RepeatUntil(lambda obj,ctx: obj > 10, Byte).parse(b"\x01\x05\x08\xff\x01\x02\x03")
+>>> RepeatUntil(lambda obj,ctx,lst: obj > 10, Byte).parse(b"\x01\x05\x08\xff\x01\x02\x03")
 [1, 5, 8, 255]
->>> RepeatUntil(lambda obj,ctx: obj > 10, Byte).build(range(20))
+>>> RepeatUntil(lambda obj,ctx,lst: obj > 10, Byte).build(range(20))
 b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b'
-
-
-

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -268,7 +268,7 @@ GreedyRange is essentially a Range from 0 to infinity.
 
 RepeatUntil is different than the others. Each element is tested by a lambda predicate. The predicate signals when a given element is the terminal element. The repeater inserts all previous items along with the terminal one, and returns just the same.
 
->>> RepeatUntil(lambda obj,ctx,lst: obj > 10, Byte).parse(b"\x01\x05\x08\xff\x01\x02\x03")
+>>> RepeatUntil(lambda obj,lst,ctx: obj > 10, Byte).parse(b"\x01\x05\x08\xff\x01\x02\x03")
 [1, 5, 8, 255]
->>> RepeatUntil(lambda obj,ctx,lst: obj > 10, Byte).build(range(20))
+>>> RepeatUntil(lambda obj,lst,ctx: obj > 10, Byte).build(range(20))
 b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b'


### PR DESCRIPTION
This makes it easy to implement things that depend on history while parsing. For example
parsing fields that have a maximum length or a terminal condition:

```py
RepeatUntil(lambda obj, ctx: ctx[-1] == 4 or len(ctx)>= 43, Byte)
```

This would parse bytes until one of them was 4 or 43 of them were read,
whichever happens first.
Conveniently the `ListContainer` already takes `-1` to mean 'the latest thing parsed'.

On the other hand, this is an API change which breaks the `obj_` abstraction, which does not currently support indexing. That is, `obj_[-1] == 4` will not work as expected `(lambda obj, ctx: obj[-1] == 4)`.

This is related to #281 and solves the problem much more compactly and logically than #282 but will require more nuanced rethinking of the meaning of which context is made available while building as well as the mechanism to make this context conveniently available.

Before merging this work in progress it will be fundamental to:

- [x] Fix `obj_`
- [x] Fix all documentation related to `RepeatUntil`
- [x] Check the implementation of `CString` and any other thing that depends on `RepeatUntil`