### PR TITLE
Add flagbuildnone to Seek

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1744,6 +1744,7 @@ class Seek(Construct):
         super(Seek, self).__init__()
         self.at = at
         self.whence = whence
+        self.flagbuildnone = True
     def _parse(self, stream, context, path):
         at = self.at(context) if callable(self.at) else self.at
         whence = self.whence(context) if callable(self.whence) else self.whence


### PR DESCRIPTION
I think Seek should have flagbuildnone set. If used in Struct, there's no reason to rename Seek and to provide a value for it in dict when building a Struct.