### PR TITLE
fix python2 compatibility

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -81,7 +81,7 @@ def _write_stream(stream, length, data):
     if len(data) != length:
         raise FieldError("could not write bytes, expected %d, found %d" % (length, len(data)))
     written = stream.write(data)
-    if written != length:
+    if written is not None and written != length:
         raise FieldError("could not write bytes, written %d, should %d" % (written, length))
 
 


### PR DESCRIPTION
In Python 2.7, file objects do not return the number of bytes written.