### PR TITLE
Restore ability of Switch to pass through named subconstructs.

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1555,7 +1555,7 @@ class Switch(Construct):
         self.cases = cases
         self.default = default
         self.includekey = includekey
-        if all(sc.flagbuildnone for sc in cases.values()) and default.flagbuildnone:
+        if all(sc.flagbuildnone for sc in cases.values()) and getattr(default, 'flagbuildnone', False):
             self.flagbuildnone = True
     def _parse(self, stream, context, path):
         key = self.keyfunc(context) if callable(self.keyfunc) else self.keyfunc

--- a/construct/core.py
+++ b/construct/core.py
@@ -851,20 +851,15 @@ class Struct(Construct):
         obj = Container()
         context = Container(_ = context)
         for i,sc in enumerate(self.subcons):
+            subobj = sc._parse(stream, context, path)
             if sc.flagembedded:
-                subobj = list(sc._parse(stream, context, path).items())
+                subobj = list(subobj.items())
                 obj.update(subobj)
                 context.update(subobj)
             else:
-                subobj = sc._parse(stream, context, path)
                 if sc.name is not None:
                     obj[sc.name] = subobj
                     context[sc.name] = subobj
-                else:
-                    if sc.flagembedded:
-                        subobj = list(subobj.items())
-                        obj.update(subobj)
-                        context.update(subobj)
         return obj
     def _build(self, obj, stream, context, path):
         context = Container(_ = context)

--- a/construct/core.py
+++ b/construct/core.py
@@ -511,7 +511,7 @@ class BytesInteger(Construct):
     r"""
     A byte field, that parses into and builds from integers as opposed to b-strings. This is similar to Int* fields but can be much longer than 4 or 8 bytes.
 
-    .. seealso:: Analog :func:`~construct.core.BitsInteger` that operatoes on bits.
+    .. seealso:: Analog :func:`~construct.core.BitsInteger` that operates on bits.
 
     :param length: number of bytes in the field, or a function that takes context and returns int
     :param signed: whether the value is signed (two's complement), default is False (unsigned)

--- a/construct/lib/container.py
+++ b/construct/lib/container.py
@@ -171,6 +171,10 @@ class Container(dict):
 
     __iter__ = keys
 
+    def __dir__(self):
+        """For auto completion of attributes based on container values."""
+        return list(self.keys()) + list(self.__class__.__dict__) + dir(super(Container, self))
+
     def __eq__(self, other):
         if not isinstance(other, dict):
             return False

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -400,6 +400,18 @@ class TestCore(unittest.TestCase):
         assert raises(Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}, includekey=True).build, (89,2)) == SwitchError
         assert Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}).sizeof() == 2
         assert raises(Switch(lambda ctx: 5, {}).sizeof) == SwitchError
+        assert Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub}).parse(b'\x00\x02') == 2
+        assert Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub}).build(2) == b'\x00\x02'
+        assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub})).parse(b"\x00\x02") == Container(tom=2)
+        assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub})).build(Container(tom=2)) == b"\x00\x02"
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:Byte, 5:Int16ub})).parse(b"\x00\x02") == Container(lex=2)
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:Byte, 5:Int16ub})).build(Container(lex=2)) == b"\x00\x02"
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub})).parse(b"\x00\x02") == Container(lex=2)
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub})).build(Container(lex=2)) == b"\x00\x02"
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:'liz' / Byte, 5:Struct('tom' / Byte, 'bob' / Byte)})).parse(b"\x00\x02") == Container(lex=Container(tom=0)(bob=2))
+        assert Struct('lex' / Switch(lambda ctx: 5, {1:'liz' / Byte, 5:Struct('tom' / Byte, 'bob' / Byte)})).build(Container(lex=Container(tom=0)(bob=2))) == b"\x00\x02"
+        assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:Embedded(Struct('tom' / Byte, 'bob' / Byte))})).parse(b"\x00\x02") == Container(tom=0)(bob=2)
+        assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:Embedded(Struct('tom' / Byte, 'bob' / Byte))})).build(Container(tom=0)(bob=2)) == b"\x00\x02"
 
     def test_ifthenelse(self):
         common(IfThenElse(True_,  Int8ub, Int16ub), b"\x01", 1, 1)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -388,9 +388,11 @@ class TestCore(unittest.TestCase):
 
     def test_switch(self):
         assert Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}).parse(b"\x00\x02") == 2
+        assert Switch(5, {1:Byte, 5:Int16ub}).parse(b"\x00\x02") == 2
         assert Switch(lambda ctx: 6, {1:Byte, 5:Int16ub}, default=Byte).parse(b"\x00\x02") == 0
         assert Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}, includekey=True).parse(b"\x00\x02") == (5,2)
         assert Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}).build(2) == b"\x00\x02"
+        assert Switch(5, {1:Byte, 5:Int16ub}).build(2) == b"\x00\x02"
         assert Switch(lambda ctx: 6, {1:Byte, 5:Int16ub}, default=Byte).build(9) == b"\x09"
         assert Switch(lambda ctx: 5, {1:Byte, 5:Int16ub}, includekey=True).build((5,2)) == b"\x00\x02"
         assert raises(Switch(lambda ctx: 6, {1:Byte, 5:Int16ub}).parse, b"\x00\x02") == SwitchError


### PR DESCRIPTION
These following constructs were bad:

```python
assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:'tom' / Int16ub})).parse(b"\x00\x02") == Container(tom=2)
assert Struct(Switch(lambda ctx: 5, {1:'liz' / Byte, 5:Embedded(Struct('tom' / Int16ub))})).parse(b"\x00\x02") == Container(tom=2)
```

They both returned an empty Container.

Please see tests and commit comments for further details.