### PR TITLE
Add unit test for utf-8 string with trailing non-valid garbage bytes

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -780,6 +780,7 @@ class TestCore(unittest.TestCase):
         assert String(5, trimdir="left").build(b"1234567890") == b"67890"
         assert String(5, padchar=b"X", paddir="left", encoding="utf8").sizeof() == 5
         assert String(5).sizeof() == 5
+        assert String(3, encoding="utf8").parse(b"a\x00\xFF") == u"a"
 
     def test_pascalstring(self):
         assert PascalString(Byte).parse(b"\x05hello????????") == b"hello"


### PR DESCRIPTION
This reproduces the issue from #307 where a String cannot be parsed if there is random data after the final \x00 byte.