### PR TITLE
Fix building for RepeatUntil with list

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1144,9 +1144,9 @@ class RepeatUntil(Subconstruct):
         except ConstructError:
             raise RangeError("missing terminator when parsing")
     def _build(self, obj, stream, context, path):
-        for subobj in obj:
+        for i, subobj in enumerate(obj):
             self.subcon._build(subobj, stream, context, path)
-            if self.predicate(subobj, obj, context):
+            if self.predicate(subobj, obj[:i+1], context):
                 break
         else:
             raise RangeError("missing terminator when building")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -281,6 +281,7 @@ class TestCore(unittest.TestCase):
         assert raises(RepeatUntil(obj_ == 9, Byte).build, [2,3,8]) == RangeError
         assert raises(RepeatUntil(obj_ == 9, Byte).sizeof) == SizeofError
         assert RepeatUntil(lambda x,lst,ctx: lst[-2:]==[0,0], Byte).parse(b"\x01\x00\x00\xff") == [1,0,0]
+        assert RepeatUntil(lambda x,lst,ctx: lst[-2:]==[0,0], Byte).build([1,0,0,4]) == b"\x01\x00\x00"
 
     def test_struct(self):
         assert Struct("a" / Int16ul, "b" / Byte).parse(b"\x01\x00\x02") == Container(a=1)(b=2)


### PR DESCRIPTION
Commit 4836722 implements a `RepeatUntil` with an extra current-list argument.

This fails when building, as the list is always complete.
A solution is to take a partial list as subconstructs are built.
This PR implements both the solution and an extra test.