### PR TITLE
Failing test about missing context on Prefixed

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -2318,7 +2318,7 @@ class Compressed(Tunnel):
 #===============================================================================
 class LazyStruct(Construct):
     r"""
-    Equivalent to Struct construct, however fixed size members are parsed on demend, others are parsed immediately. If entire struct is fixed size then entire parse is essentially one seek.
+    Equivalent to Struct construct, however fixed size members are parsed on demand, others are parsed immediately. If entire struct is fixed size then entire parse is essentially one seek.
 
     .. seealso:: Equivalent to :func:`~construct.core.Struct`.
 

--- a/docs/lazy.rst
+++ b/docs/lazy.rst
@@ -16,11 +16,11 @@ Essentially almost every code that uses the base classes also works on these but
 
 `LazyStruct` works like Struct but parses into a LazyContainer.
 
-    Equivalent to Struct construct, however fixed size members are parsed on demend, others are parsed immediately. If entire struct is fixed size then entire parse is essentially one seek.
+    Equivalent to Struct construct, however fixed size members are parsed on demand, others are parsed immediately. If entire struct is fixed size then entire parse is essentially one seek.
 
 `LazySequence` works like Sequence but parses into a LazySequenceContainer.
 
-    Equivalent to Sequence construct, however fixed size members are parsed on demend, others are parsed immediately. If entire sequence is fixed size then entire parse is essentially one seek.
+    Equivalent to Sequence construct, however fixed size members are parsed on demand, others are parsed immediately. If entire sequence is fixed size then entire parse is essentially one seek.
 
 `LazyRange` works like Range but parses into a LazyRangeContainer.
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -711,6 +711,12 @@ class TestCore(unittest.TestCase):
         assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub, GreedyBytes)).parse(b"\x02\x00\xff????????") == [0,255,b'']
         assert raises(Prefixed(VarInt, GreedyBytes).sizeof) == SizeofError
 
+    def test_prefixed_check(self):
+        test = Struct(Prefixed("length" / Byte, "vals" / Byte),
+                      "pointer" / Pointer(-this.length, Byte))
+        indata = b"\x01\x01\x01"
+        assert indata == test.build(test.parse(indata))
+
     def test_compressed_zlib(self):
         zeros = bytes(10000)
         d = Compressed(GreedyBytes, "zlib")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -711,12 +711,6 @@ class TestCore(unittest.TestCase):
         assert Prefixed(Byte, Sequence(Peek(Byte), Int16ub, GreedyBytes)).parse(b"\x02\x00\xff????????") == [0,255,b'']
         assert raises(Prefixed(VarInt, GreedyBytes).sizeof) == SizeofError
 
-    def test_prefixed_check(self):
-        test = Struct(Prefixed("length" / Byte, "vals" / Byte),
-                      "pointer" / Pointer(-this.length, Byte))
-        indata = b"\x01\x01\x01"
-        assert indata == test.build(test.parse(indata))
-
     def test_compressed_zlib(self):
         zeros = bytes(10000)
         d = Compressed(GreedyBytes, "zlib")


### PR DESCRIPTION
I guess when Prefixed is used, the prefix should be added to the
context.