### PR TITLE
Add posargs to tox to be able to pass more args to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps=pytest
      pytest-cov
      numpy
 commands=
-    py.test --cov {envsitepackagesdir}/construct --cov-report html --cov-report term --verbose
+    py.test --cov {envsitepackagesdir}/construct --cov-report html --cov-report term --verbose {posargs}


### PR DESCRIPTION
i.e. --lf to run only last failures, or -s that let the
Debugger in construct work.