### PR TITLE
Prefixed instead of Array

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1089,10 +1089,10 @@ def Array(count, subcon):
 
 def PrefixedArray(lengthfield, subcon):
     r"""
-    An array prefixed by a length field (as opposed to preixed by byte count, see :func:`~construct.core.Prefixed`).
+    An array prefixed by a length field (as opposed to prefixed by byte count, see :func:`~construct.core.Prefixed`).
 
-    :param lengthfield: a field parsing and building an integer
-    :param subcon: the subcon to process individual elements
+    :param lengthfield: field parsing and building an integer
+    :param subcon: subcon to process individual elements
 
     Example::
 

--- a/construct/core.py
+++ b/construct/core.py
@@ -1089,7 +1089,7 @@ def Array(count, subcon):
 
 def PrefixedArray(lengthfield, subcon):
     r"""
-    An array prefixed by a length field (as opposed to preixed by byte count, see :func:`~construct.core.Array`).
+    An array prefixed by a length field (as opposed to preixed by byte count, see :func:`~construct.core.Prefixed`).
 
     :param lengthfield: a field parsing and building an integer
     :param subcon: the subcon to process individual elements


### PR DESCRIPTION
The class that has a byte-length field before the data is
construct.core.Prefixed and not construct.core.Array