### PR TITLE
Embedded Switch 2nd patch

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1561,6 +1561,12 @@ class Switch(Construct):
         else:
             key = self.keyfunc(context) if callable(self.keyfunc) else self.keyfunc
         case = self.cases.get(key, self.default)
+        if self.name is None and case.name is not None:
+            self.name = case.name
+            try:
+                obj = obj[self.name]
+            except (KeyError, IndexError, TypeError):
+                pass
         return case._build(obj, stream, context, path)
     def _sizeof(self, context, path):
         try:

--- a/construct/core.py
+++ b/construct/core.py
@@ -1549,8 +1549,8 @@ class Switch(Construct):
         self.cases = cases
         self.default = default
         self.includekey = includekey
-        self.flagbuildnone = all(sc.flagbuildnone for sc in cases.values())
-        self.flagembedded = all(sc.flagembedded for sc in cases.values())
+        self.flagbuildnone = all(sc.flagbuildnone for sc in cases.values() if sc is not Pass)
+        self.flagembedded = all(sc.flagembedded for sc in cases.values() if sc is not Pass)
     def _parse(self, stream, context, path):
         key = self.keyfunc(context) if callable(self.keyfunc) else self.keyfunc
         obj = self.cases.get(key, self.default)._parse(stream, context, path)

--- a/construct/core.py
+++ b/construct/core.py
@@ -1552,8 +1552,11 @@ class Switch(Construct):
         self.cases = cases
         self.default = default
         self.includekey = includekey
-        self.flagbuildnone = all(sc.flagbuildnone for sc in cases.values() if sc is not Pass)
-        self.flagembedded = all(sc.flagembedded for sc in cases.values() if sc is not Pass)
+        all_cases = list(cases.values())
+        if default is not self.NoDefault:
+            all_cases.append(default)
+        self.flagbuildnone = all(sc.flagbuildnone for sc in all_cases if sc is not Pass)
+        self.flagembedded = all(sc.flagembedded for sc in all_cases if sc is not Pass)
     def _parse(self, stream, context, path):
         key = self.keyfunc(context) if callable(self.keyfunc) else self.keyfunc
         case = self.cases.get(key, self.default)


### PR DESCRIPTION
Fix for issue #357 

The default value was not being included in computing the flags.

In this case `flagbuildnone` was not set to true, even though `Computed` as the default has this as `True`.