### PR TITLE
Adding missing parameter to `PrintContext` in docs

### DIFF
--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -7,7 +7,7 @@ Meta constructs are the key to the declarative power of Construct. Meta construc
 In order to see the context, let's try this snippet:
 
 >>> class PrintContext(Construct):
-...     def _parse(self, stream, context):
+...     def _parse(self, stream, context, path):
 ...         print(context)
 ...
 >>> st = Struct(


### PR DESCRIPTION
Brings it in line with changes made in https://github.com/construct/construct/commit/2a615c597f5a21aaa40e7869a085ba5ea56467d6