### PR TITLE
Tune .gitignore to ignore .tox directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 build/
 .pypirc
 .cache
+.tox


### PR DESCRIPTION
Add .tox to .gitignore to ensure it will never be added