### PR TITLE
Returns empty bytes object when substream is already at EOF

### DIFF
--- a/construct/lib/bitstream.py
+++ b/construct/lib/bitstream.py
@@ -24,7 +24,7 @@ class RestreamedBytesIO(object):
         while len(self.rbuffer) < count:
             data = self.substream.read(self.decoderunit)
             if data is None or len(data) == 0:
-                raise IOError("Restreamed cannot satisfy read request of %d %s" % (count, self.decoderunitname))
+                break
             self.rbuffer += self.decoder(data)
         data, self.rbuffer = self.rbuffer[:count], self.rbuffer[count:]
         self.sincereadwritten += count

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -381,8 +381,10 @@ class TestCore(unittest.TestCase):
     def test_terminated(self):
         common(Terminated, b"", None, 0)
         common(Struct("end"/Terminated), b"", Container(end=None), 0)
+        common(BitStruct("end"/Terminated), b"", Container(end=None), 0)
         assert raises(Terminated.parse, b"x") == TerminatedError
         assert raises(Struct("end"/Terminated).parse, b"x") == TerminatedError
+        assert raises(BitStruct("end"/Terminated).parse, b"x") == TerminatedError
 
     def test_error(self):
         assert raises(Error.parse, b"") == ExplicitError
@@ -1381,7 +1383,7 @@ class TestCore(unittest.TestCase):
 
     def test_hanging_issue_280(self):
         st = BitStruct('a'/BitsInteger(20), 'b'/BitsInteger(12))
-        assert raises(st.parse, b'\x00') == IOError
+        assert raises(st.parse, b'\x00') == FieldError
 
     def test_nonbytes_checksum_issue_323(self):
         st = Struct(


### PR DESCRIPTION
Returns empty bytes object when substream is already at EOF. 
Brings it in line with [BufferedIOBase](https://docs.python.org/2.7/library/io.html#io.BufferedIOBase.read). 
Fixes Issue #378.