### PR TITLE
Example ipstack: Add missing ICMP payload

### DIFF
--- a/construct/examples/protocols/ipstack.py
+++ b/construct/examples/protocols/ipstack.py
@@ -734,6 +734,7 @@ layer3_payload = "next" / Switch(this.header.protocol,
     {
         "TCP" : layer4_tcp,
         "UDP" : layer4_udp,
+        "ICMP" : icmp_header,
     },
     default = Pass
 )


### PR DESCRIPTION
I use the `layer3_ipv4` in my app and discovered that properly tested ICMP protocol is not used anywhere except the test suite.

Before:
```
ipv4 = Container: 
    header = Container: 
        version = 4
        header_length = 20
        tos = Container: 
            precedence = 0
            minimize_delay = False
            high_throuput = False
            high_reliability = False
            minimize_cost = False
        total_length = 60
        payload_length = 40
        identification = 7126
        flags = Container: 
            dont_fragment = False
            more_fragments = False
        frame_offset = 0
        ttl = 128
        protocol = ICMP (total 4)
        checksum = 62945
        source = 13.0.253.232 (total 12)
        destination = 12.0.18.33 (total 10)
        options =  (total 0)
    next = None
```
After:
```
ipv4 = Container: 
    header = Container: 
        version = 4
        header_length = 20
        tos = Container: 
            precedence = 0
            minimize_delay = False
            high_throuput = False
            high_reliability = False
            minimize_cost = False
        total_length = 60
        payload_length = 40
        identification = 7126
        flags = Container: 
            dont_fragment = False
            more_fragments = False
        frame_offset = 0
        ttl = 128
        protocol = ICMP (total 4)
        checksum = 62945
        source = 13.0.253.232 (total 12)
        destination = 12.0.18.33 (total 10)
        options =  (total 0)
    next = Container: 
        type = Echo_request (total 12)
        code = 0
        crc = 19743
        payload = Container: 
            identifier = 1
            sequence = 60
            data = abcdefghijklmnopqrstuvwabcdefghi (total 32)
```