### PR TITLE
FIX: Left-shift operator

### DIFF
--- a/construct/expr.py
+++ b/construct/expr.py
@@ -51,7 +51,7 @@ class ExprMixin(object):
     def __rshift__(self, other):
         return BinExpr(operator.rshift, self, other)
     def __lshift__(self, other):
-        return BinExpr(operator.rshift, self, other)
+        return BinExpr(operator.lshift, self, other)
     def __and__(self, other):
         return BinExpr(operator.and_, self, other)
     def __or__(self, other):
@@ -77,7 +77,7 @@ class ExprMixin(object):
     def __rrshift__(self, other):
         return BinExpr(operator.rshift, other, self)
     def __rlshift__(self, other):
-        return BinExpr(operator.rshift, other, self)
+        return BinExpr(operator.lshift, other, self)
     def __rand__(self, other):
         return BinExpr(operator.and_, other, self)
     def __ror__(self, other):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1505,7 +1505,7 @@ class TestCore(unittest.TestCase):
         assert test["lshift_1"] == 4
         assert test["lshift_2"] == 8
 
-    def test_lshift(self):
+    def test_rshift(self):
         test = Struct(
            "a" / Byte,
            "rshift_0" / Computed(this["a"] >> 0),

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1493,3 +1493,27 @@ class TestCore(unittest.TestCase):
             assert FORMAT.parse(b'\x00').my_tell == 0
         for i in range(5):
             assert BIT_FORMAT.parse(b'\x00').my_tell == 0
+
+    def test_lshift(self):
+        test = Struct(
+           "a" / Byte,
+           "lshift_0" / Computed(this["a"] << 0),
+           "lshift_1" / Computed(this["a"] << 1),
+           "lshift_2" / Computed(this["a"] << 2),
+        ).parse(b"\x02")
+        assert test["lshift_0"] == 2
+        assert test["lshift_1"] == 4
+        assert test["lshift_2"] == 8
+
+    def test_lshift(self):
+        test = Struct(
+           "a" / Byte,
+           "rshift_0" / Computed(this["a"] >> 0),
+           "rshift_1" / Computed(this["a"] >> 1),
+           "rshift_2" / Computed(this["a"] >> 2),
+        ).parse(b"\x08")
+        assert test["rshift_0"] == 8
+        assert test["rshift_1"] == 4
+        assert test["rshift_2"] == 2
+
+

--- a/tests/test_this.py
+++ b/tests/test_this.py
@@ -42,8 +42,8 @@ class TestThis(unittest.TestCase):
     def test_path(self):
         path = Path("path")
         x = ~((path.foo * 2 + 3 << 2) % 11)
-        assert str(x) == 'not ((((path.foo * 2) + 3) >> 2) % 11)'
-        assert repr(x) == 'not ((((path.foo * 2) + 3) >> 2) % 11)'
+        assert str(x) == 'not ((((path.foo * 2) + 3) << 2) % 11)'
+        assert repr(x) == 'not ((((path.foo * 2) + 3) << 2) % 11)'
         assert not x(dict(foo=7))
 
     def test_obj(self):


### PR DESCRIPTION
### Bug

The `<<` operator acts like the `>>` operator in certain cases.

### Minimum Working Example

```python
>>> from construct import *
>>> Test = Struct(
...    "a_byte" / Byte,
...    "test_rshift" / Computed(this["a_byte"] >> 1),
...    "test_lshift" / Computed(this["a_byte"] << 1),
... )
>>> Test.parse(b"\x01")
Container(a_byte=1)(test_rshift=0)(test_lshift=0)
```

### Solution

The operator overloads for `__lshift__` and `__rlshift__` in `construct/expr.py` call `operator.rshift` where they should call `operator.lshift`. 

After replacing these, things work as expected:

```python
>>> from construct import *
>>> Test = Struct(
...    "a_byte" / Byte,
...    "test_rshift" / Computed(this["a_byte"] >> 1),
...    "test_lshift" / Computed(this["a_byte"] << 1),
... )
>>> Test.parse(b"\x01")
Container(a_byte=1)(test_rshift=0)(test_lshift=2)
```