### PR TITLE
add the missing assertions to test_from_issue_298

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1025,7 +1025,9 @@ class TestCore(unittest.TestCase):
             "optional"/If(this.ctrl == "NAK", Byte),
         )
         assert st.parse(b"\x15\xff") == Container(ctrl='NAK')(optional=255)
+        assert b"\x15\xff" == st.build(Container(ctrl='NAK')(optional=255))
         assert st.parse(b"\x02") == Container(ctrl='STX')(optional=None)
+        assert b"\x02" == st.build(Container(ctrl='STX')(optional=None))
 
     def test_flagsenum(self):
         assert FlagsEnum(Byte, a=1,b=2,c=4,d=8,e=16,f=32,g=64,h=128).parse(b'\x81') == FlagsContainer(a=True,b=False,c=False,d=False,e=False,f=False,g=False,h=True)


### PR DESCRIPTION
Add the missing assertions for bug https://github.com/construct/construct/issues/298

Only assertions for parsing were added but the bug was in building.

I suspect that the bug originates in this change: https://github.com/construct/construct/commit/489c78c23fde24b959559b47c492cd1234494252#commitcomment-25640446

(Regarding the failed check in CI - this is expected due to adding the failing assertion)