### PR TITLE
Fix Travis e-mail notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script: py.test --benchmark-skip --verbose
 
 notifications:
     email:
-        receipients:
+        recipients:
             - arek.bulski@gmail.com


### PR DESCRIPTION
Due to a spelling mistake, the Travis e-mail notification settings weren’t properly configured. This fixes the spelling error, which should make the Travis notifications work again for @arekbulski.