### PR TITLE
Add support for multi-bit flags

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1921,7 +1921,7 @@ class FlagsEnum(Adapter):
         obj2 = Container()
         obj2._flagsenum = True
         for name,value in self.flags.items():
-            obj2[BitwisableString(name)] = bool(obj & value)
+            obj2[BitwisableString(name)] = (obj & value == value)
         return obj2
 
     def _encode(self, obj, context, path):


### PR DESCRIPTION
The current `FlagsEnum` implementation doesn't handle flag values that have multiple bits set.

For instance, take the `IMAGE_SCN_ALIGN_64BYTES` flag (0x00700000) from the PE specification. Setting this flag will make the current implementation think that `IMAGE_SCN_ALIGN_8192BYTES` (0x00E00000) is also set, which is clearly incorrect.