### PR TITLE
use importlib to make module checks faster

### DIFF
--- a/construct/lib/py3compat.py
+++ b/construct/lib/py3compat.py
@@ -5,11 +5,13 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 PYPY = '__pypy__' in sys.builtin_module_names
 
-try:
-    import numpy
-    supportsnumpy = True
-except ImportError:
-    supportsnumpy = False
+@property
+def supportsnumpy():
+    try:
+        import numpy
+        return True
+    except ImportError:
+        return False
 try:
     import ruamel.yaml
     assert PY3


### PR DESCRIPTION
There are a few `try-except` blocks in `py3compat.py` which make imports really slow (mostly numpy).

Ideally you would get rid of the `import *` statements in `construct/__init__.py`, because otherwise if you import *anything* from `construct`, you have to import everything in `core.py`, `expr.py` and `debug.py`.  However, this would constitute a major api change.

At the very least, you can avoid importing the things in `py3compat.py` by using `importlib`.

Here's the profiler output for the import time of `from construct.core import Struct` before and after my changes.

![](https://i.imgur.com/QUsJmCm.png)

![](https://i.imgur.com/oxKy1JN.png)