### PR TITLE
allow Select to build from none if any of its subcons can

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -3522,7 +3522,9 @@ def Optional(subcon):
         >>> d.build(None)
         b''
     """
-    return Select(subcon, Pass)
+    select = Select(subcon, Pass)
+    select.flagbuildnone = True
+    return select
 
 
 def If(condfunc, subcon):

--- a/construct/core.py
+++ b/construct/core.py
@@ -3470,7 +3470,7 @@ class Select(Construct):
     def __init__(self, *subcons, **subconskw):
         super(Select, self).__init__()
         self.subcons = list(subcons) + list(k/v for k,v in subconskw.items())
-        self.flagbuildnone = all(sc.flagbuildnone for sc in self.subcons)
+        self.flagbuildnone = any(sc.flagbuildnone for sc in self.subcons)
         self.flagembedded = all(sc.flagembedded for sc in self.subcons)
 
     def _parse(self, stream, context, path):
@@ -3522,9 +3522,7 @@ def Optional(subcon):
         >>> d.build(None)
         b''
     """
-    select = Select(subcon, Pass)
-    select.flagbuildnone = True
-    return select
+    return Select(subcon, Pass)
 
 
 def If(condfunc, subcon):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -756,7 +756,14 @@ def test_optional():
     assert d.build(None) == b""
     assert raises(d.sizeof) == SizeofError
 
-def test_optional_missing_in_struct():
+def test_select_buildfromnone():
+    d = Struct("select" / Select(Int32ub, Default(Bytes(3), b"abc")))
+    assert d.parse(b"def") == dict(select=b"def")
+    assert d.parse(b"\x01\x02\x03\x04") == dict(select=0x01020304)
+    assert d.build(dict(select=b"def")) == b"def"
+    assert d.build(dict(select=0xbeefcace)) == b"\xbe\xef\xca\xce"
+    assert d.build(dict()) == b"abc"
+
     d = Struct("opt" / Optional(Byte))
     assert d.build(dict(opt=1)) == b"\x01"
     assert d.build(dict()) == b""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -756,6 +756,11 @@ def test_optional():
     assert d.build(None) == b""
     assert raises(d.sizeof) == SizeofError
 
+def test_optional_missing_in_struct():
+    d = Struct("opt" / Optional(Byte))
+    assert d.build(dict(opt=1)) == b"\x01"
+    assert d.build(dict()) == b""
+
 def test_if():
     common(If(True,  Byte), b"\x01", 1, 1)
     common(If(False, Byte), b"", None, 0)


### PR DESCRIPTION
Right now, when building `Struct("opt" / Optional)`, the key `opt` must be specified, even if its value is `None`.
There's been a couple issues about this, I've read the response in #710 in particular. I understand why the behavior of `Optional` is as described above, but ISTM it doesn't _need_ to be that way.

Given that the code change is actually very simple, and it seems technically correct, I went ahead and made a PR.

Rationale: `Optional` is equal to `Select(subcon, Pass)`, so there is no practical difference between sending `None` to subcon explicitly and having it fail, and sending `None` implicitly when no value is provided. So technically speaking, `flagbuildnone` is true for this particular form of `Select` even in cases when it is false for subcon.
(if the subcon would instead _succeed_ when building `None`, then the `select.flagbuildnone` would be true _anyway_, and so for that case, this change is a no-op)

In effect, this change allows `Optional` to behave same as `Default(Optional, None)`