### PR TITLE
Instructions added for installation from conda.

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -82,3 +82,7 @@ The library is downloadable and installable from Pypi. Just use standard command
 
 * pip install construct
 * pip install construct[extras]
+
+For Anaconda users, the library is also available from `conda-forge <https://conda-forge.org/>`_. To install, use
+
+* conda install -c conda-forge construct


### PR DESCRIPTION
I like using construct with Anaconda Python on Windows, so I added it to [conda-forge](https://conda-forge.org/). This commit adds the command to the install options for construct.