### PR TITLE
Allow BitsInteger to be Little-Endian

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1189,8 +1189,6 @@ class BitsInteger(Construct):
             raise IntegerError("length must be non-negative")
         data = stream_read(stream, length)
         if self.swapped:
-            if length & 7:
-                raise IntegerError("little-endianness is only defined for multiples of 8 bits")
             data = swapbytes(data)
         return bits2integer(data, self.signed)
 
@@ -1206,8 +1204,6 @@ class BitsInteger(Construct):
             raise IntegerError("length must be non-negative")
         data = integer2bits(obj, length)
         if self.swapped:
-            if length & 7:
-                raise IntegerError("little-endianness is only defined for multiples of 8 bits")
             data = swapbytes(data)
         stream_write(stream, data, length)
         return obj


### PR DESCRIPTION
Removed arbitrary restriction of BitsInteger to be multiple of 8.

The following example works as expected:
>>> BitsInteger(2,swapped=True).parse('\x01\x00')
3