### PR TITLE
Add .value and .name property getters to EnumIntegerString class

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1679,6 +1679,14 @@ class EnumIntegerString(str):
         ret = EnumIntegerString(stringvalue)
         ret.intvalue = intvalue
         return ret
+    
+    @property
+    def value(self):
+        return self.intvalue
+
+    @property
+    def name(self):
+        return str(self)
 
 
 class Enum(Adapter):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -304,6 +304,17 @@ def test_enum_issue_677():
     d = Struct("e" / Enum(Byte, one=1)).compile()
     assert str(d.parse(b"\x01")) == 'Container: \n    e = (enum) one 1'
     assert str(d.parse(b"\xff")) == 'Container: \n    e = (enum) (unknown) 255'
+    
+def test_enum_prop_getters():
+    MyEnum = Enum(
+        BitsInteger(1),
+        foo=0,
+        bar=1
+    )
+    assert MyEnum.foo.value == 0
+    assert MyEnum.bar.value == 1
+    assert MyEnum.foo.name == 'foo'
+    assert MyEnum.bar.name == 'bar'
 
 def test_flagsenum():
     d = FlagsEnum(Byte, one=1, two=2, four=4, eight=8)


### PR DESCRIPTION
Add property getters: .value and .name for EnumIntegerString class, so that it can be used as python's builtin enum.

Example:

  ```python
MyEnum = Enum(
    BitsInteger(1),
    foo=0,
    bar=1
)
MyEnum.foo.value
>> 0
MyEnum.foo.name
>> 'foo'
```