### PR TITLE
Enabling GitHub actions as Travis drop in

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,5 @@ jobs:
           pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml
       - name: Run tests
         run: |
+          export PYTHONPATH=$PYTHONPATH:`pwd`
           py.test tests/ --benchmark-disable --showlocals --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -22,5 +22,4 @@ jobs:
           pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml
       - name: Run tests
         run: |
-          cd tests
-          py.test --benchmark-disable --showlocals --verbose
+          py.test tests/ --benchmark-disable --showlocals --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', 'pypy2', 'pypy3' ]
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install dependencies  
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml
+      - name: Run tests
+        run: |
+          cd tests
+          py.test --benchmark-disable --showlocals --verbose


### PR DESCRIPTION
Enabling Github Actions for CI testing. Supported versions:
* Python 3.5 - 3.8
* PyPy2 and PyPy3