### PR TITLE
Add publish step into actions flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,20 @@
-name: CI
+name: build
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
+    name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', 'pypy2', 'pypy3' ]
-    name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1
       - name: Setup python
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
       - name: Install dependencies  
         run: |
           python -m pip install --upgrade pip
@@ -24,3 +23,22 @@ jobs:
         run: |
           export PYTHONPATH=$PYTHONPATH:`pwd`
           py.test tests/ --benchmark-disable --showlocals --verbose
+  deploy:
+    name: Build and Publish into PyPI
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build package
+        run: python setup.py sdist
+      - name: Publish package
+        # FIXME update to stable release when it will be ready
+        uses: pypa/gh-action-pypi-publish@74be6d3
+        with:
+          password: ${{ secrets.pypi_password }}
+

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 Construct 2.9
 ===================
 
+|build-status|
+
+.. |build-status| image:: https://github.com/construct/construct/workflows/build/badge.svg
+   :alt: build status
+   :scale: 100%
+   :target: https://github.com/construct/construct/actions
+
 Construct is a powerful **declarative** and **symmetrical** parser and builder for binary data.
 
 Instead of writing *imperative code* to parse a piece of data, you declaratively define a *data structure* that describes your data. As this data structure is not code, you can use it in one direction to *parse* data into Pythonic objects, and in the other direction, to *build* objects into binary data.


### PR DESCRIPTION
Added job and steps for build and publish package into PyPI. This job only runs if test success and on push of tagged revision (i.e. git tag is actual version).
Publish step requires token from PyPI (as described [here](https://pypi.org/help/#apitoken)), stored as  `pypi_password` in Secrets in settings of Github repository ([see here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)).

See https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ for reference.
