### PR TITLE
fix build_file in python2

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -367,7 +367,7 @@ class Construct(object):
         r"""
         Build an object into a closed binary file. See build().
         """
-        with open(filename, 'wb') as f:
+        with io.open(filename, 'wb') as f:
             self.build_stream(obj, f, **contextkw)
 
     def _build(self, obj, stream, context, path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2129,3 +2129,6 @@ def test_hex_issue_709():
     d = Struct("x" / Struct("y" / Hex(Bytes(1))))
     obj = d.parse(b"\xff")
     assert "y = unhexlify('ff')" in str(obj)
+
+def test_buildfile_issue_737():
+    Byte.build_file(Byte.parse(b'\xff'), 'out')


### PR DESCRIPTION
This is a fix for #737.

In python3, `open()` and `io.open()` are the same, but in python2 `open()` is not the same and does not return the number of bytes written.

https://www.reddit.com/r/learnpython/comments/7wnldj/ioopen_vs_open/