### PR TITLE
add python version requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url = "http://construct.readthedocs.org",
     author = "Arkadiusz Bulski, Tomer Filiba, Corbin Simpson",
     author_email = "arek.bulski@gmail.com, tomerfiliba@gmail.com, MostAwesomeDude@gmail.com",
+    python_requires = ">=3.6",
     install_requires = [],
     extras_require = {
         "extras": [


### PR DESCRIPTION
This allows `pip` to pick an older version of Construct on Python 3.5 (and 2.7 presumably). Currently pip attempts to download the latest version, which then fails to install.

It would be super nice if you could apply this patch and then unpublish the version(s?) that break python 3.5 compatibility