### PR TITLE
Add endianity property to FormatField #858

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1015,6 +1015,7 @@ class FormatField(Construct):
         self.fmtstr = endianity+format
         self.length = struct.calcsize(endianity+format)
         self.packer = struct.Struct(endianity+format)
+        self.endianity = 'little' if endianity == '<' or endianity == '=' and sys.byteorder == 'little' else 'big'
 
     def _parse(self, stream, context, path):
         data = stream_read(stream, self.length, path)


### PR DESCRIPTION
Narrative:
```
# The new feature will allow me to do as such:
struct.megic.to_bytes(MY_STRUT.megic.sizeof(), MY_STRUT.megic.endianity)
```