### PR TITLE
Update Array sizeof() to take index into account

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -2246,7 +2246,11 @@ class Array(Subconstruct):
                 count = count(context)
         except (KeyError, AttributeError):
             raise SizeofError("cannot calculate size, key not found in context", path=path)
-        return count * self.subcon._sizeof(context, path)
+        size = 0
+        for i in range(count):
+            context._index = i
+            size += self.subcon._sizeof(context, path)
+        return size
 
     def _emitparse(self, code):
         return "ListContainer((this.__setitem__('_index',i),(%s))[1] for i in range(%s))" % (self.subcon._compileparse(code), self.count, )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -469,7 +469,7 @@ def test_computed():
 
 def test_index():
     d = Array(3, Bytes(this._index+1))
-    common(d, b"abbccc", [b"a", b"bb", b"ccc"])
+    common(d, b"abbccc", [b"a", b"bb", b"ccc"], 6)
     d = GreedyRange(Bytes(this._index+1))
     common(d, b"abbccc", [b"a", b"bb", b"ccc"])
     d = RepeatUntil(lambda o,l,ctx: ctx._index == 2, Bytes(this._index+1))


### PR DESCRIPTION
This fixes the issue with `Array` not taking `_index` into account when calculating size.

closes #877 