### PR TITLE
build_file() stream reading

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -86,8 +86,8 @@ def stream_read(stream, length, path):
         raise StreamError("length must be non-negative, found %s" % length, path=path)
     try:
         data = stream.read(length)
-    except Exception as e:
-        raise StreamError("stream.read() failed, requested %s bytes" % (length,), path=path) from e
+    except Exception:
+        raise StreamError("stream.read() failed, requested %s bytes" % (length,), path=path)
     if len(data) != length:
         raise StreamError("stream read less than specified amount, expected %d, found %d" % (length, len(data)), path=path)
     return data

--- a/construct/core.py
+++ b/construct/core.py
@@ -86,8 +86,8 @@ def stream_read(stream, length, path):
         raise StreamError("length must be non-negative, found %s" % length, path=path)
     try:
         data = stream.read(length)
-    except Exception:
-        raise StreamError("stream.read() failed, requested %s bytes" % (length,), path=path)
+    except Exception as e:
+        raise StreamError("stream.read() failed, requested %s bytes" % (length,), path=path) from e
     if len(data) != length:
         raise StreamError("stream read less than specified amount, expected %d, found %d" % (length, len(data)), path=path)
     return data

--- a/construct/core.py
+++ b/construct/core.py
@@ -351,7 +351,10 @@ class Construct(object):
         r"""
         Build an object into a closed binary file. See build().
         """
-        with open(filename, 'wb') as f:
+        # Open the file for reading as well as writing. This allows builders to
+        # read back the stream just written. For example. RawCopy does this.
+        # See issue #888.
+        with open(filename, 'w+b') as f:
             self.build_stream(obj, f, **contextkw)
 
     def _build(self, obj, stream, context, path):

--- a/tests/declarativeunittest.py
+++ b/tests/declarativeunittest.py
@@ -3,7 +3,7 @@ xfail = pytest.mark.xfail
 skip = pytest.mark.skip
 skipif = pytest.mark.skipif
 
-import os, math, random, collections, itertools, io, hashlib, binascii
+import os, math, random, collections, itertools, io, hashlib, binascii, tempfile
 
 from construct import *
 from construct.lib import *

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -930,6 +930,13 @@ def test_rawcopy_issue_358():
     d = Struct("a"/RawCopy(Byte), "check"/Check(this.a.value == 255))
     assert d.build(dict(a=dict(value=255))) == b"\xff"
 
+def test_rawcopy_issue_888(tmpdir):
+    # If you use build_file() on a RawCopy that has only a value defined, then
+    # RawCopy._build may also attempt to read from the file, which won't work
+    # if build_file opened the file for writing only.
+    d = RawCopy(Byte)
+    d.build_file(dict(value=0), filename=tmpdir.join('test'))
+
 def test_byteswapped():
     d = ByteSwapped(Bytes(5))
     common(d, b"12345", b"54321", 5)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -930,12 +930,13 @@ def test_rawcopy_issue_358():
     d = Struct("a"/RawCopy(Byte), "check"/Check(this.a.value == 255))
     assert d.build(dict(a=dict(value=255))) == b"\xff"
 
-def test_rawcopy_issue_888(tmpdir):
+def test_rawcopy_issue_888():
     # If you use build_file() on a RawCopy that has only a value defined, then
     # RawCopy._build may also attempt to read from the file, which won't work
     # if build_file opened the file for writing only.
-    d = RawCopy(Byte)
-    d.build_file(dict(value=0), filename=tmpdir.join('test'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        d = RawCopy(Byte)
+        d.build_file(dict(value=0), filename=os.path.join(tmpdir, 'test'))
 
 def test_byteswapped():
     d = ByteSwapped(Bytes(5))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -935,8 +935,9 @@ def test_rawcopy_issue_888():
     # RawCopy._build may also attempt to read from the file, which won't work
     # if build_file opened the file for writing only.
     with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, 'test')
         d = RawCopy(Byte)
-        d.build_file(dict(value=0), filename=os.path.join(tmpdir, 'test'))
+        d.build_file(dict(value=0), filename=fname)
 
 def test_byteswapped():
     d = ByteSwapped(Bytes(5))


### PR DESCRIPTION
This is to fix #888.

I can think of two broad approaches to fix this:

 1) Require that all streams given to `_build()` are both readable and writeable. In this view, `build_file()` is in error, and is trivial to    adjust. This is the approach I took here.

 2) Require that `_build()` methods cannot assume that streams are writeable. Then we could fix this by having `RawCopy._build()` create a memory stream, give that to its subcon, and then write out what is written to its output stream as well as keeping the copy for its data attribute. Done carefully, no additional memory would be required as `RawCopy` by design keeps a copy of all data written out anyway. Having just learned about this library, I'm not sure if there would be other implications I don't know about though.
