### PR TITLE
pytests now also works on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,4 @@ jobs:
           pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml cloudpickle lz4
       - name: Run tests
         run: |
-          export PYTHONPATH=$PYTHONPATH:`pwd`
           py.test tests/ --benchmark-disable --showlocals --verbose

--- a/tests/declarativeunittest.py
+++ b/tests/declarativeunittest.py
@@ -1,4 +1,7 @@
 import pytest
+import platform
+import io
+
 xfail = pytest.mark.xfail
 skip = pytest.mark.skip
 skipif = pytest.mark.skipif
@@ -9,8 +12,22 @@ from construct import *
 from construct.lib import *
 
 ident = lambda x: x
-devzero = open("/dev/zero", "rb")
+if platform.system() == "Windows":
+    class ZeroIO(io.BufferedIOBase):
+        def read(self, __size=None):
+            if __size is not None:
+                return bytes(__size)
+            else:
+                return bytes(0)
 
+        def read1(self, __size=0):
+            return bytes(__size)
+
+    devzero = ZeroIO()
+else:    
+    devzero = open("/dev/zero", "rb")
+
+        
 
 def raises(func, *args, **kw):
     try:

--- a/tests/deprecated_gallery/test_formats.py
+++ b/tests/deprecated_gallery/test_formats.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/deprecated_gallery/test_protocols.py
+++ b/tests/deprecated_gallery/test_protocols.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/gallery/test_gallery.py
+++ b/tests/gallery/test_gallery.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/lib/test_binary.py
+++ b/tests/lib/test_binary.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct.lib.binary import *
 
 

--- a/tests/lib/test_bitstream.py
+++ b/tests/lib/test_bitstream.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct.lib.bitstream import *
 
 

--- a/tests/lib/test_containers_dict.py
+++ b/tests/lib/test_containers_dict.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/lib/test_containers_list.py
+++ b/tests/lib/test_containers_list.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/lib/test_hex.py
+++ b/tests/lib/test_hex.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct.lib.hex import *
 
 

--- a/tests/lib/test_py3compat.py
+++ b/tests/lib/test_py3compat.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct.lib.py3compat import *
 
 

--- a/tests/lib/test_search.py
+++ b/tests/lib/test_search.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
-from test_compiler import example, exampledata
+from tests.test_compiler import example, exampledata
 
 
 def test_class_bytes_parse(benchmark):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1938,6 +1938,7 @@ def test_isparsingbuilding():
     )
     d.sizeof()
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="'/dev/zero' is not available on windows")
 def test_struct_stream():
     d = Struct(
         'fixed' / FixedSized(10, Struct(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,4 +1,4 @@
-from declarativeunittest import *
+from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -2,14 +2,12 @@ from declarativeunittest import *
 from construct import *
 from construct.lib import *
 
+def worker(q):
+    obj = q.get()
+    print(obj)
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="test fails on windows")
 def test_multiprocessing():
     import multiprocessing
-
-    def worker(q):
-        obj = q.get()
-        print(obj)
 
     queue = multiprocessing.Queue()
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -3,6 +3,7 @@ from construct import *
 from construct.lib import *
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="test fails on windows")
 def test_multiprocessing():
     import multiprocessing
 


### PR DESCRIPTION
With this fix the pytest now also runs on my Windows 10 machine. The main problem is, that `/dev/zero` is not available on Windows.

The second problem is in `test_multiprocessing`, but i have not investigated further and ignored for now. This error message was thrown: 
```
FAILED tests/test_multiprocessing.py::test_multiprocessing - AttributeError: Can't pickle local object 'test_multiprocessing.<locals>.worker'
```