### PR TITLE
fixed __copy__ of construct

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -267,7 +267,7 @@ class Construct(object):
 
     def __copy__(self):
         self2 = object.__new__(self.__class__)
-        self2.__setstate__(self, self.__getstate__())
+        self2.__setstate__(self.__getstate__())
         return self2
 
     def parse(self, data, **contextkw):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2189,3 +2189,14 @@ def test_struct_issue_771():
     assert spec.build(info) == data
     assert spec.sizeof(**info) == 10
 
+def test_struct_copy():
+    import copy
+    d = Struct(
+        "a" / Int16ub,
+        "b" / Int8ub
+    )
+    d_copy = copy.copy(d)
+    
+    common(d, b"\x00\x01\x02", Container(a=1,b=2), 3)
+    common(d_copy, b"\x00\x01\x02", Container(a=1,b=2), 3)
+    


### PR DESCRIPTION
This fixes a bug, when a construct should be copied with `copy.copy(...)`