### PR TITLE
Lazy seek

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -5292,6 +5292,8 @@ class Lazy(Subconstruct):
             obj = self.subcon._parsereport(stream, context, path)
             stream_seek(stream, fallback, 0, path)
             return obj
+        len = self.subcon._actualsize(self, context, path)
+        stream_seek(stream, len, 1, path)
         return execute
 
     def _build(self, obj, stream, context, path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1344,6 +1344,20 @@ def test_lazy():
     assert d.build(x) == b'\x00'
     assert d.sizeof() == 1
 
+def test_lazy_seek():
+    d = Struct(
+        "a" / Int8ul,
+        "b" / Lazy(Bytes(2)),
+        "c" / Int16ul,
+        "d" / Lazy(Bytes(4))
+    )
+    obj = d.parse(b"\x01\x01\x02\x45\x67\x04\x98\x76\x65")
+
+    assert obj.a == 1
+    assert obj.b() == b'\x01\x02'
+    assert obj.c == 26437
+    assert obj.d() == b'\x04\x98\x76\x65'
+
 def test_lazystruct():
     d = LazyStruct(
         "num1" / Int8ub,


### PR DESCRIPTION
Even if the data behind Lazy() is not parsed the amount of bytes have to be seeked in the stream anyway.

Once I found out that I need to install `pytest-benchmark` for the tests, I could even add a test case.