### PR TITLE
Use explicit imports to avoid future AttributeErrors

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib
+import importlib.machinery
+import importlib.util
 
 from construct.lib import *
 from construct.expr import *


### PR DESCRIPTION
The CPython internals could change in future and using explicit imports will help in safeguarding.

Similar issue in gcloud : https://issuetracker.google.com/issues/170125513
Found in https://github.com/yozik04/vallox_websocket_api/issues/15