### PR TITLE
import importlib.util

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib
+import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.lib
 
 from construct.lib import *
 from construct.expr import *

--- a/construct/core.py
+++ b/construct/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.lib
+import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.util
 
 from construct.lib import *
 from construct.expr import *


### PR DESCRIPTION
import importlib.util

Without this specific import at least line 444 will fail to execute. 
I had this issue, search on the documentation, and this is how it is documented. 

https://docs.python.org/3/library/importlib.html 