### PR TITLE
AttributeError: module 'importlib' has no attribute 'util'

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib
+import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.util
 
 from construct.lib import *
 from construct.expr import *


### PR DESCRIPTION
I was getting this error in line 444 without the "import importlib.util"

After reading the documentation, this solved the issue.

https://docs.python.org/3/library/importlib.html