### PR TITLE
Declare Python 3.10 as official supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3' ]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -64,7 +64,7 @@ Main documentation is at `readthedocs <http://construct.readthedocs.org>`_, whic
 
 Requirements
 --------------
-Construct should run on CPython 3.6 3.7 3.8 3.9 and PyPy implementations. PyPy achieves much better performance. Therefore PyPy would be somewhat recommended.
+Construct should run on CPython 3.6 3.7 3.8 3.9 3.10 and PyPy implementations. PyPy achieves much better performance. Therefore PyPy would be somewhat recommended.
 
 Following modules are needed only if you want to use certain features:
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
This PR updates the docs and the CI, so that Python 3.10 is official supported. The CI passes without problems for Python 3.10.