### PR TITLE
Build wheel and sdist in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,20 @@ jobs:
       - name: Run tests
         run: |
           py.test tests/ --benchmark-disable --showlocals --verbose
+
+  create_wheel_and_sdist:
+    name: Build binary and source archives
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build twine pip setuptools wheel
+      - name: Build wheel and sdist
+        run: |
+          python setup.py sdist bdist_wheel
+          twine check dist/*
+      - name: Collect built archives
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ html:
 
 installdeps:
 	apt-get install python3.9 python3-pip python3-sphinx --upgrade
-	python3.9 -m pip install pytest pytest-benchmark pytest-cov twine --upgrade
+	python3.9 -m pip install pytest pytest-benchmark pytest-cov twine wheel --upgrade
 	python3.9 -m pip install enum34 numpy arrow ruamel.yaml cloudpickle lz4 --upgrade
 
 version:
 	./version-increment
 
 upload:
-	python3.9 ./setup.py sdist
+	python3.9 ./setup.py sdist bdist_wheel
+	python3.9 -m twine check dist/*
 	python3.9 -m twine upload dist/*
-


### PR DESCRIPTION
This adds a new job in the GitHub workflow to build
a wheel and a source distribution.
 
Reference: https://github.com/construct/construct/issues/974
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>