### PR TITLE
fix bitwise Hex() adapter

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.machinery, importlib.util
+import math, struct, io, binascii, itertools, collections, pickle, sys, os, hashlib, importlib, importlib.machinery, importlib.util
 
 from construct.lib import *
 from construct.expr import *
 from construct.version import *
-
 
 #===============================================================================
 # exceptions
@@ -3517,7 +3516,10 @@ class Hex(Adapter):
     """
     def _decode(self, obj, context, path):
         if isinstance(obj, integertypes):
-            return HexDisplayedInteger.new(obj, "0%sX" % (2 * self.subcon._sizeof(context, path)))
+            size = 2 * self.subcon._sizeof(context, path)
+            if isinstance(context._io, RestreamedBytesIO) and context._io.decoderunit == 1:
+                size = math.ceil(size / 8)
+            return HexDisplayedInteger.new(obj, "0%sX" % size)
         if isinstance(obj, bytestringtype):
             return HexDisplayedBytes(obj)
         if isinstance(obj, dict):


### PR DESCRIPTION
```
d = BitStruct(
    "number" / Hex(BitsInteger(12))
)
```

This generates `number = 0x000000000000000000000701`. There's 24 digits because the adapter uses bit length instead of byte length.

My PR patches the adapter. `number = 0x701`.