### PR TITLE
Add _emitfulltype to Optional and _emitprimitivetype to Peek

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -4469,6 +4469,11 @@ class Peek(Subconstruct):
     def _sizeof(self, context, path):
         return 0
 
+    def _emitprimitivetype(self, ksy, bitwise):
+        name = "instance_%s" % ksy.allocateId()
+        ksy.instances[name] = dict(**self.subcon._compilefulltype(ksy, bitwise))
+        return name
+
     def _emitparse(self, code):
         code.append("""
             def parse_peek(io, func):


### PR DESCRIPTION
I'm in the process of exporting Structs to Kaitai schemas, and the `Optional` field is something I use very often. 

I figure that since `Optional` is typically parsed only when data is available, then using `not(_.io.eof)` could be used to achieve similar functionality. Or is there something else I'm missing here?