### PR TITLE
Resolve lambdas in Container __getattr__

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2383,6 +2383,18 @@ def test_switch_issue_913_using_integers():
     common(d, b"\xab", 171, 1, x=1)
     common(d, b"\x09\x00", 9, 2, x=2)
 
+
+def test_lazy_rebuild():
+    d = Struct(
+        "foo" / Int32ul,
+        "bar" / Rebuild(Int32ul, lambda ctx: ctx.baz),
+        "baz" / Rebuild(Int32ul, lambda ctx: ctx.foo),
+    )
+    obj = {"foo": 4, "bar": lambda ctx: ctx.baz, "baz": lambda ctx: ctx.foo}
+    res = d.build(obj)
+    assert(res == b'\x04\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00')
+
+
 @xfail(reason="unfixable defect in the design")
 def test_adapters_context_issue_954():
     class IdAdapter(Adapter):


### PR DESCRIPTION
Currently using Rebuild is only useful when parsing, because the dictionary gets filled with value copys:

``` python
    d = Struct(
        "foo" / Int32ul,
        "bar" / Rebuild(Int32ul, lambda ctx: ctx.baz),
        "baz" / Rebuild(Int32ul, lambda ctx: ctx.foo),
    )
    data = b'\x04\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00'
    obj = d.parse(data)
    # Container(foo=4, bar=4, baz=4)
```

However this isn't useful when building, because you don't know in later stages about the rebuilding, and when the parameters change, you'd need to change all of them.

With this change it is possible to put ```lambda ctx: ctx.foo``` into the Container, which get resolved immediately, when accessed. (See the test case)

This could be expanded upon, so that Rebuild itself just add these to the Container when parsing, or that a possible preprocessing step adds these before building.

The inspect hack is necessary to not break the existing behaviour of Lazy adding lambdas into the Container, which get resolved and return not the lambda, but the resulting value directly.