### PR TITLE
Update _emitfulltype for Bytes to export lengths if Paths are passed in

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -960,7 +960,10 @@ class Bytes(Construct):
         return f"(io.write(obj), obj)[1]"
 
     def _emitfulltype(self, ksy, bitwise):
+        if isinstance(self.length, Path):
+            return dict(size=str(self.length).replace('this[\'', '').replace('\']', ''))
         return dict(size=self.length)
+
 
 
 @singleton


### PR DESCRIPTION
While exporting `Bytes(this.insert_name_here)`, I encountered `cannot represent an object: this['insert_name_here']` since `_emitfulltype` can't support `Path` objects being passed in as lengths. While this isn't the most graceful solution, I figured it'd be worth opening discussion on this. Are there any other classes that have similar methods that should have their `_emitfulltype` methods needing to be similarly updated as well?