### PR TITLE
Fix missing objects in Struct._emitbuild's context

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -2269,6 +2269,7 @@ class Struct(Construct):
             def {fname}(obj, io, this):
                 this = Container(_ = this, _params = this['_params'], _root = None, _parsing = False, _building = True, _sizing = False, _subcons = None, _io = io, _index = this.get('_index', None))
                 this['_root'] = this['_'].get('_root', this)
+                this.update(obj)
                 try:
                     objdict = obj
         """

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -166,6 +166,10 @@ example = Struct(
     "len1" / Computed(len_(this.items1)),
     Check(this.len1 == 3),
 
+    "len2" / Rebuild(Computed(5), len_(this.items2)),
+    "items2" / Bytes(5),
+    Check(this.len2 == 5),
+
     # WARNING: faulty list_ implementation, but compiles into correct code?
     # "repeatuntil2" / RepeatUntil(list_ == [0], Byte),
     # "repeatuntil3" / RepeatUntil(obj_ == 0, Byte),


### PR DESCRIPTION
Union already had this line in its own _emitbuild method and Struct had it in its _build method.
