### PR TITLE
Update actions and include Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,19 +8,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3' ]
         exclude:
           - os: windows-latest
             python-version: pypy3
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - name: Install dependencies  
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml cloudpickle lz4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: pypy3.9
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v3
       - name: Setup python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9' ]
         exclude:
           - os: windows-latest
-            python-version: pypy3
+            python-version: pypy3.9
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest pytest-benchmark enum34 numpy arrow ruamel.yaml cloudpickle lz4
       - name: Install cryptography (but not for pypy on windows)
-        if: ${{ !((matrix.os == 'windows-latest') && (matrix.python-version == 'pypy3')) }}
+        if: ${{ !((matrix.os == 'windows-latest') && (matrix.python-version == 'pypy3.9')) }}
         run: |
           pip install cryptography
       - name: Run tests


### PR DESCRIPTION
The update for actions/checkout and actions/setup-python are required, because the old version still rely on Nodejs 12, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ for more details.

Python 3.11 is added, because it is released for quite some time now and needs to be ensured that no changes are introduced that break 3.11.

Update: Replaced "pypy3" by "pypy3.9", because actions/setup-python@v4 doesn't accept "pypy3" anymore. The choice of PyPy 3.9 is arbitrary. Not sure which versions should be tested.

Also I made the OS name visible in the job description.