### PR TITLE
Use builtin dict in Container for Python >=3.7

### DIFF
--- a/construct/lib/containers.py
+++ b/construct/lib/containers.py
@@ -246,6 +246,20 @@ class Container(OrderedDict):
         compiled_pattern = re.compile(pattern)
         return self._search(compiled_pattern, True)
 
+    def __getstate__(self):
+        """
+        Used by pickle to serialize an instance to a dict.
+        """
+        ret = OrderedDict(self)
+        return ret
+
+    def __setstate__(self, state):
+        """
+        Used by pickle to de-serialize from a dict.
+        """
+        self.clear()
+        self.update(state)
+
 
 class ListContainer(list):
     r"""

--- a/construct/lib/containers.py
+++ b/construct/lib/containers.py
@@ -1,6 +1,11 @@
 from construct.lib.py3compat import *
 import re
 import collections
+import sys
+
+OrderedDict = dict
+if sys.version_info < (3, 7):
+    OrderedDict = collections.OrderedDict
 
 
 globalPrintFullStrings = False
@@ -56,7 +61,7 @@ def recursion_lock(retval="<recursion detected>", lock_name="__recursion_lock__"
     return decorator
 
 
-class Container(collections.OrderedDict):
+class Container(OrderedDict):
     r"""
     Generic ordered dictionary that allows both key and attribute access, and preserves key order by insertion. Adding keys is preferred using \*\*entrieskw (requires Python 3.6). Equality does NOT check item order. Also provides regex searching.
 


### PR DESCRIPTION
I started using construct, and noticed the parsing performance differences to Kaitai. I then looked for bottlenecks using cProfile, and it looks to me that the creation and handling of `Container` instances is probably at the center of it, especially for compiled structs, where the byte reading operations are not such a large issue anymore.

I wonder if it might give a performance boost to use a class factory/metaclass to create struct-specific container classes with `__slots__` for fields instead of using a dict, but diving into that, to see how and if it can be possible, will take some more time and work.

So for now I rather looked at the low-hanging fruits, and noticed that it should be possible to speed up the `Container` class by using `dict` instead of `collections.OrderedDict` if Python version  >= 3.7. I looked at the issue tracker at https://github.com/construct/construct/issues/869, but I think it should be worthwhile to revisit that, so I just derived `Container` from `dict`. For backwards compatibility I added a small version check. I know that `dict` is ordered in 3.6, but that is still an implementation detail.

It should be no problem since `Container` comes with its own `__eq__` method (`OrderedDict.__eq__` is more strict, it also checks order, while `dict.__eq__` only checks membership). All tests in the repo ran successfully after the change.

In benchmarks I saw about 10-20% speedup in both compiled and non-compiled cases using CPython 3.11. I did not test PyPy.