### PR TITLE
change `Container` implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9' ]
         exclude:
           - os: windows-latest
             python-version: pypy3.9

--- a/construct/lib/containers.py
+++ b/construct/lib/containers.py
@@ -1,11 +1,6 @@
 from construct.lib.py3compat import *
 import re
-import collections
 import sys
-
-OrderedDict = dict
-if sys.version_info < (3, 7):
-    OrderedDict = collections.OrderedDict
 
 
 globalPrintFullStrings = False
@@ -61,9 +56,9 @@ def recursion_lock(retval="<recursion detected>", lock_name="__recursion_lock__"
     return decorator
 
 
-class Container(OrderedDict):
+class Container(dict):
     r"""
-    Generic ordered dictionary that allows both key and attribute access, and preserves key order by insertion. Adding keys is preferred using \*\*entrieskw (requires Python 3.6). Equality does NOT check item order. Also provides regex searching.
+    Generic ordered dictionary that allows both key and attribute access, and preserves key order by insertion. Adding keys is preferred using \*\*entrieskw. Equality does NOT check item order. Also provides regex searching.
 
     Note that not all parameters can be accessed via attribute access (dot operator). If the name of an item matches a method name of the Container, it can only be accessed via key acces (square brackets). This includes the following names: clear, copy, fromkeys, get, items, keys, move_to_end, pop, popitem, search, search_all, setdefault, update, values.
 
@@ -71,9 +66,8 @@ class Container(OrderedDict):
 
         # empty dict
         >>> Container()
-        # list of pairs, not recommended
-        >>> Container([ ("name","anonymous"), ("age",21) ])
-        # This syntax requires Python 3.6
+        # sequence of pairs
+        >>> Container([("name", "anonymous"), ("age", 21)])
         >>> Container(name="anonymous", age=21)
         # copies another dict
         >>> Container(dict2)
@@ -88,71 +82,48 @@ class Container(OrderedDict):
             text = u'utf8 decoded string...' (total 22)
             value = 123
     """
-    __slots__ = ["__recursion_lock__"]
+    __slots__ = ('__dict__', '__recursion_lock__')
 
-    def __getattr__(self, name):
-        try:
-            if name in self.__slots__:
-                return object.__getattribute__(self, name)
-            else:
-                return self[name]
-        except KeyError:
-            raise AttributeError(name)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
 
-    def __setattr__(self, name, value):
-        try:
-            if name in self.__slots__:
-                return object.__setattr__(self, name, value)
-            else:
-                self[name] = value
-        except KeyError:
-            raise AttributeError(name)
+    def copy(self, /):
+        return self.__class__(self)
 
-    def __delattr__(self, name):
-        try:
-            if name in self.__slots__:
-                return object.__delattr__(self, name)
-            else:
-                del self[name]
-        except KeyError:
-            raise AttributeError(name)
+    def __copy__(self, /):
+        return self.copy()
 
-    def update(self, seqordict):
-        """Appends items from another dict/Container or list-of-tuples."""
-        if isinstance(seqordict, dict):
-            seqordict = seqordict.items()
-        for k,v in seqordict:
-            self[k] = v
+    # this is required because otherwise deepcopy will
+    # copy self and self.__dict__ separately for some reason
+    def __deepcopy__(self, _, /):
+        return self.copy()
 
-    def copy(self):
-        return Container(self)
-
-    __update__ = update
-
-    __copy__ = copy
-
-    def __dir__(self):
+    def __dir__(self, /):
         """For auto completion of attributes based on container values."""
         return list(self.keys()) + list(self.__class__.__dict__) + dir(super(Container, self))
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         if self is other:
             return True
         if not isinstance(other, dict):
             return False
+
         def isequal(v1, v2):
             if v1.__class__.__name__ == "ndarray" or v2.__class__.__name__ == "ndarray":
                 import numpy
+
                 return numpy.array_equal(v1, v2)
             return v1 == v2
-        for k,v in self.items():
+
+        for k, v in self.items():
             if isinstance(k, unicodestringtype) and k.startswith(u"_"):
                 continue
             if isinstance(k, bytestringtype) and k.startswith(b"_"):
                 continue
             if k not in other or not isequal(v, other[k]):
                 return False
-        for k,v in other.items():
+        for k, v in other.items():
             if isinstance(k, unicodestringtype) and k.startswith(u"_"):
                 continue
             if isinstance(k, bytestringtype) and k.startswith(b"_"):
@@ -161,13 +132,13 @@ class Container(OrderedDict):
                 return False
         return True
 
-    def __ne__(self, other):
-       return not self == other
+    def __ne__(self, other, /):
+        return not self == other
 
     @recursion_lock()
-    def __repr__(self):
+    def __repr__(self, /):
         parts = []
-        for k,v in self.items():
+        for k, v in self.items():
             if isinstance(k, str) and k.startswith("_"):
                 continue
             if isinstance(v, stringtypes):
@@ -177,20 +148,26 @@ class Container(OrderedDict):
         return "Container(%s)" % ", ".join(parts)
 
     @recursion_lock()
-    def __str__(self):
+    def __str__(self, /):
         indentation = "\n    "
         text = ["Container: "]
         isflags = getattr(self, "_flagsenum", False)
-        for k,v in self.items():
+        for k, v in self.items():
             if isinstance(k, str) and k.startswith("_") and not globalPrintPrivateEntries:
                 continue
             if isflags and not v and not globalPrintFalseFlags:
                 continue
             text.extend([indentation, str(k), " = "])
             if v.__class__.__name__ == "EnumInteger":
-                text.append("(enum) (unknown) %s" % (v, ))
+                text.append("(enum) (unknown) %s" % (v,))
             elif v.__class__.__name__ == "EnumIntegerString":
-                text.append("(enum) %s %s" % (v, v.intvalue, ))
+                text.append(
+                    "(enum) %s %s"
+                    % (
+                        v,
+                        v.intvalue,
+                    )
+                )
             elif v.__class__.__name__ in ["HexDisplayedBytes", "HexDumpDisplayedBytes"]:
                 text.append(indentation.join(str(v).split("\n")))
             elif isinstance(v, bytestringtype):
@@ -198,22 +175,26 @@ class Container(OrderedDict):
                 if len(v) <= printingcap or globalPrintFullStrings:
                     text.append("%s (total %d)" % (reprstring(v), len(v)))
                 else:
-                    text.append("%s... (truncated, total %d)" % (reprstring(v[:printingcap]), len(v)))
+                    text.append(
+                        "%s... (truncated, total %d)" % (reprstring(v[:printingcap]), len(v))
+                    )
             elif isinstance(v, unicodestringtype):
                 printingcap = 32
                 if len(v) <= printingcap or globalPrintFullStrings:
                     text.append("%s (total %d)" % (reprstring(v), len(v)))
                 else:
-                    text.append("%s... (truncated, total %d)" % (reprstring(v[:printingcap]), len(v)))
+                    text.append(
+                        "%s... (truncated, total %d)" % (reprstring(v[:printingcap]), len(v))
+                    )
             else:
                 text.append(indentation.join(str(v).split("\n")))
         return "".join(text)
 
-    def _search(self, compiled_pattern, search_all):
+    def _search(self, compiled_pattern, search_all, /):
         items = []
         for key in self.keys():
             try:
-                if isinstance(self[key], (Container,ListContainer)):
+                if isinstance(self[key], (Container, ListContainer)):
                     ret = self[key]._search(compiled_pattern, search_all)
                     if ret is not None:
                         if search_all:
@@ -246,14 +227,13 @@ class Container(OrderedDict):
         compiled_pattern = re.compile(pattern)
         return self._search(compiled_pattern, True)
 
-    def __getstate__(self):
+    def __getstate__(self, /):
         """
         Used by pickle to serialize an instance to a dict.
         """
-        ret = OrderedDict(self)
-        return ret
+        return dict(self)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state, /):
         """
         Used by pickle to de-serialize from a dict.
         """
@@ -272,8 +252,10 @@ class ListContainer(list):
 
     ::
 
+        >>> obj
+        ListContainer([1, 2, 3])
         >>> print(repr(obj))
-        [1, 2, 3]
+        ListContainer([1, 2, 3])
         >>> print(obj)
         ListContainer
             1
@@ -282,11 +264,11 @@ class ListContainer(list):
     """
 
     @recursion_lock()
-    def __repr__(self):
-        return "ListContainer(%s)" % (list.__repr__(self), )
+    def __repr__(self, /):
+        return "ListContainer(%s)" % (list.__repr__(self),)
 
     @recursion_lock()
-    def __str__(self):
+    def __str__(self, /):
         indentation = "\n    "
         text = ["ListContainer: "]
         for k in self:
@@ -295,7 +277,7 @@ class ListContainer(list):
             text.append(indentation.join(lines))
         return "".join(text)
 
-    def _search(self, compiled_pattern, search_all):
+    def _search(self, compiled_pattern, search_all, /):
         items = []
         for item in self:
             try:

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -127,23 +127,14 @@ Thanks to blapid, containers can also be searched. Structs nested within Structs
 >>> con.search_all("a")
 [1, 2]
 
-Note that not all methods can be accessed via attribute access. If the name of an item matches a method name of a ``Container`` (which is a subclass of ``dict``), method will not be accessible through instance. You should call the method through class instead: ``Container.method(con, ...)``
+Note that not all parameters can be accessed via attribute access (dot operator). If the name of an item matches a method name of the Container (which is based on a dict), it can only be accessed via key acces (square brackets). This includes the following names: clear, copy, fromkeys, get, items, keys, move_to_end, pop, popitem, search, search_all, setdefault, update, values.
 
->>> con = Container()
->>> con.update
-<built-in method update of Container object at ...>
->>> con.update = 5
->>> con['update']
+>>> con = Container(update=5)
+>>> con["update"]
 5
->>> con.update
-5
->>> con.update(x=42)
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-TypeError: 'int' object is not callable
->>> Container.update(con, x=42)
->>> con
-Container(update=5, x=42)
+>>> con.update  # not usable via dot access
+<bound method Container.update of Container(update=5)>
+
 
 Nesting and embedding
 ---------------------

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -127,14 +127,23 @@ Thanks to blapid, containers can also be searched. Structs nested within Structs
 >>> con.search_all("a")
 [1, 2]
 
-Note that not all parameters can be accessed via attribute access (dot operator). If the name of an item matches a method name of the Container (which is based on a dict), it can only be accessed via key acces (square brackets). This includes the following names: clear, copy, fromkeys, get, items, keys, move_to_end, pop, popitem, search, search_all, setdefault, update, values.
+Note that not all methods can be accessed via attribute access. If the name of an item matches a method name of a ``Container`` (which is a subclass of ``dict``), method will not be accessible through instance. You should call the method through class instead: ``Container.method(con, ...)``
 
->>> con = Container(update=5)
->>> con["update"]
+>>> con = Container()
+>>> con.update
+<built-in method update of Container object at ...>
+>>> con.update = 5
+>>> con['update']
 5
->>> con.update  # not usable via dot access
-<bound method Container.update of Container(update=5)>
-
+>>> con.update
+5
+>>> con.update(x=42)
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+TypeError: 'int' object is not callable
+>>> Container.update(con, x=42)
+>>> con
+Container(update=5, x=42)
 
 Nesting and embedding
 ---------------------

--- a/tests/lib/test_containers_dict.py
+++ b/tests/lib/test_containers_dict.py
@@ -312,7 +312,6 @@ def test_method_shadowing_2():
         # __deepcopy__=print,
         # __class__=int, # this will break a lot of things, this should not be supported
     )
-    c.c = c
 
     dir(c)
     assert c == copy.copy(c)

--- a/tests/lib/test_containers_dict.py
+++ b/tests/lib/test_containers_dict.py
@@ -290,8 +290,36 @@ def test_regression_recursionlock():
     str(c); repr(c)
     assert not c
 
-def test_method_shadowing():
+def test_method_shadowing_1():
     c = Container()
     assert c.update != 42
     c['update'] = 42
     assert c.update == 42
+
+def test_method_shadowing_2():
+    # TODO: test more possible things that might break if some method is shadowed
+    # ensure that methods work even if shadowed
+    import copy
+    c = Container(
+        x=42,
+        items='foo',
+        keys='bar',
+        __init__='',
+        search=lambda *_: 1/0,
+        update=lambda *_: 1/0,
+        copy=print,
+        # __copy__=print, # copy calls these two methods through instance, this will break things if is shadowed
+        # __deepcopy__=print,
+        # __class__=int, # this will break a lot of things, this should not be supported
+    )
+    c.c = c
+
+    dir(c)
+    assert c == copy.copy(c)
+    assert c == copy.deepcopy(c)
+    assert c is not copy.copy(c)
+    assert c is not copy.deepcopy(c)
+    assert Container.search(c, 'x') == 42
+    assert Container.search(c, 'y') == None
+    pytest.raises(ZeroDivisionError, c.search, 'x')
+

--- a/tests/lib/test_containers_dict.py
+++ b/tests/lib/test_containers_dict.py
@@ -289,3 +289,9 @@ def test_regression_recursionlock():
     c = Container()
     str(c); repr(c)
     assert not c
+
+def test_method_shadowing():
+    c = Container()
+    assert c.update != 42
+    c['update'] = 42
+    assert c.update == 42


### PR DESCRIPTION
Change `Container` implementation. This implementation is **5x** faster on my machine on CPython3.12.
This is a **backwards incompatible** change:
- **the biggest problem:** shadowing behaviour changed. Before `con.update` was always referring to method, now it will refer to container item called `update` (if it exists, otherwise it will be a method). I added new test to ensure that behaviour. All other container-related tests pass perfectly. Documentation was updated too. There is a couple in the `core.py` that was using methods directly, they probably should be updated to do `Container.method(ctx, ...)`
- `__(get|set|del)attr__` methods were removed. If anybody is calling them directly (`con.__getattr__('foo')`), this code will break
- `Container.update` method was removed. It wasn't doing anything that `dict.update` is not able to do. Nothing should break
- `__update__` method was removed. Not sure what it was doing. It is not referenced anywhere in the codebase, and it is not a special dunder.
- some private and dunder methods don't accept kwargs anymore
- whoops, I accidentally ran `black` on the file, so there is a couple of formatting changes 

Benchmark code:
```py
import timeit
N = 10**8
for _ in range(10):
    t = timeit.timeit('c.x', 'from construct import Container; c = Container(x=5)', number=N) / N
    print(round(t * 10**9), 'ns')

```
Original implementation:
```py
149 ns
164 ns
164 ns
163 ns
163 ns
174 ns
162 ns
165 ns
169 ns
163 ns
```
New implementation:
```py
26 ns
26 ns
28 ns
26 ns
30 ns
30 ns
31 ns
34 ns
31 ns
31 ns
```