### PR TITLE
Allow for user supplied functions in compiled mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-benchmark numpy arrow ruamel.yaml cloudpickle lz4
+          pip install "pytest<8.0.0" pytest-benchmark numpy arrow ruamel.yaml cloudpickle lz4
       - name: Install cryptography (but not for pypy on windows)
         if: ${{ !((matrix.os == 'windows-latest') && (matrix.python-version == 'pypy3.9')) }}
         run: |

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -641,6 +641,18 @@ def test_rebuild_issue_664():
     # no asserts are needed
     d.build(obj)
 
+
+def test_rebuild_custom_function():
+    def getlen(this):
+        return 2
+
+    template = Struct(      "count" / Rebuild(Byte, getlen), "my_items" / Byte[this.count])
+    for d  in [template, template.compile()]:
+        assert d.parse(b"\x02ab") == Container(count=2, my_items=[97,98])
+        assert d.build(dict(count=None,my_items=[255,255])) == b"\x02\xff\xff"
+        assert d.build(dict(count=2,my_items=[255,255])) == b"\x02\xff\xff"
+        assert d.build(dict(my_items=[255,255])) == b"\x02\xff\xff"
+
 def test_default():
     d = Default(Byte, 0)
     common(d, b"\xff", 255, 1)


### PR DESCRIPTION
This fixes https://github.com/construct/construct/issues/1065

It adds a dictionary "userfunction" which works the same as linkedbuilders / linkedparsers. This dictionary is used to store the user supplied functions which are then referenced in the compiled construct.

The decission weather or not we have a user supplied function at hand is donne by.:

```python
if isinstance(self.func, ExprMixin) or (not callable(self.func)):
    #dont use the userfunction 
else:
    #use the userfunction   
```

Rebuild is not the only place where this makes sense. "IfThenElse" and "Switch" can also benefit of this improvement.

