### PR TITLE
- add pytest.ini file to enable pytest 8.x.y to find the tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+


### PR DESCRIPTION
pytest 8 changed the way how tests get discovered, adding this ini file makes it find the pytests of construct 

This is a very simple change, which should not need a lot of review before accepting/rejecting it.

