### PR TITLE
- do not limit pytest version in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "pytest<8.0.0" pytest-benchmark numpy arrow ruamel.yaml cloudpickle lz4
+          pip install pytest pytest-benchmark numpy arrow ruamel.yaml cloudpickle lz4
       - name: Install cryptography (but not for pypy on windows)
         if: ${{ !((matrix.os == 'windows-latest') && (matrix.python-version == 'pypy3.9')) }}
         run: |


### PR DESCRIPTION
- this is a worse solution to the pytest doesnt find the tests problem, which is no longer needed

I am sorry, this sliped through as the Rebuild fix is older than the pytest config fix...

