### PR TITLE
Compileability mandatory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.9' ]
         exclude:
           - os: windows-latest
             python-version: pypy3.9

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.13"
 
 python:
   install:

--- a/construct/core.py
+++ b/construct/core.py
@@ -7,6 +7,14 @@ from construct.expr import *
 from construct.version import *
 
 
+def _emit_function_expression_or_const(code, func, parameters="this"):
+    if isinstance(func, ExprMixin) or (not callable(func)):
+        return repr(func)
+    else:
+        aid = code.allocateId()
+        code.userfunction[aid] = func
+        return f"userfunction[{aid}]({parameters})"
+
 #===============================================================================
 # exceptions
 #===============================================================================
@@ -980,7 +988,7 @@ class Bytes(Construct):
             raise SizeofError("cannot calculate size, key not found in context", path=path)
 
     def _emitparse(self, code):
-        return f"io.read({self.length})"
+        return f"io.read({_emit_function_expression_or_const(code, self.length)})"
 
     def _emitbuild(self, code):
         return f"(io.write(obj), obj)[1]"
@@ -2924,10 +2932,10 @@ class Computed(Construct):
         return 0
 
     def _emitparse(self, code):
-        return repr(self.func)
+        return _emit_function_expression_or_const(code, self.func)
 
     def _emitbuild(self, code):
-        return repr(self.func)
+        return _emit_function_expression_or_const(code, self.func)
 
 
 @singleton
@@ -3119,14 +3127,14 @@ class Check(Construct):
             def parse_check(condition):
                 if not condition: raise CheckError
         """)
-        return f"parse_check({repr(self.func)})"
+        return f"parse_check({_emit_function_expression_or_const(code, self.func)})"
 
     def _emitbuild(self, code):
         code.append(f"""
             def build_check(condition):
                 if not condition: raise CheckError
         """)
-        return f"build_check({repr(self.func)})"
+        return f"build_check({_emit_function_expression_or_const(code, self.func)})"
 
 
 @singleton
@@ -3987,10 +3995,10 @@ class IfThenElse(Construct):
         return sc._sizeof(context, path)
 
     def _emitparse(self, code):
-        return "((%s) if (%s) else (%s))" % (self.thensubcon._compileparse(code), self.condfunc, self.elsesubcon._compileparse(code), )
+        return "((%s) if (%s) else (%s))" % (self.thensubcon._compileparse(code), _emit_function_expression_or_const(code, self.condfunc), self.elsesubcon._compileparse(code), )
 
     def _emitbuild(self, code):
-        return f"(({self.thensubcon._compilebuild(code)}) if ({repr(self.condfunc)}) else ({self.elsesubcon._compilebuild(code)}))"
+        return f"(({self.thensubcon._compilebuild(code)}) if ({_emit_function_expression_or_const(code, self.condfunc)}) else ({self.elsesubcon._compilebuild(code)}))"
 
     def _emitseq(self, ksy, bitwise):
         return [
@@ -4249,9 +4257,11 @@ class Padded(Subconstruct):
             raise SizeofError("cannot calculate size, key not found in context", path=path)
 
     def _emitparse(self, code):
+        assert isinstance(self.length, int), "Padding needs to be known at compile time"
         return f"({self.subcon._compileparse(code)}, io.read(({self.length})-({self.subcon.sizeof()}) ))[0]"
 
     def _emitbuild(self, code):
+        assert isinstance(self.length, int), "Padding needs to be known at compile time"
         return f"({self.subcon._compilebuild(code)}, io.write({repr(self.pattern)}*(({self.length})-({self.subcon.sizeof()})) ))[0]"
 
     def _emitfulltype(self, ksy, bitwise):
@@ -4442,7 +4452,7 @@ class Pointer(Subconstruct):
                 io.seek(fallback)
                 return obj
         """)
-        return f"parse_pointer(io, {self.offset}, lambda: {self.subcon._compileparse(code)})"
+        return f"parse_pointer(io, {_emit_function_expression_or_const(code, self.offset)}, lambda: {self.subcon._compileparse(code)})"
 
     def _emitbuild(self, code):
         code.append(f"""
@@ -4453,7 +4463,7 @@ class Pointer(Subconstruct):
                 io.seek(fallback)
                 return ret
         """)
-        return f"build_pointer(obj, io, {self.offset}, lambda: {self.subcon._compilebuild(code)})"
+        return f"build_pointer(obj, io, {_emit_function_expression_or_const(code, self.offset)}, lambda: {self.subcon._compilebuild(code)})"
 
     def _emitprimitivetype(self, ksy, bitwise):
         offset = self.offset.__getfield__() if callable(self.offset) else self.offset

--- a/construct/core.py
+++ b/construct/core.py
@@ -15,6 +15,16 @@ def _emit_function_expression_or_const(code, func, parameters="this"):
         code.userfunction[aid] = func
         return f"userfunction[{aid}]({parameters})"
 
+def _emit_source_or_use_linked(code, obj):
+    try:
+        if eval(repr(obj)) == obj:
+            return repr(obj)
+    except Exception as _:
+        aid = code.allocateId()
+        code.userfunction[aid] = obj
+        return f"userfunction[{aid}]"
+
+
 #===============================================================================
 # exceptions
 #===============================================================================
@@ -2153,15 +2163,11 @@ class Mapping(Adapter):
         except (KeyError, TypeError):
             raise MappingError("building failed, no encoding mapping for %r" % (obj,), path=path)
 
-    def _emitparse(self, code):
-        fname = f"factory_{code.allocateId()}"
-        code.append(f"{fname} = {repr(self.decmapping)}")
-        return f"{fname}[{self.subcon._compileparse(code)}]"
+    def _emitdecode(self, code):
+        return f"{_emit_source_or_use_linked(code, self.decmapping)}[obj]"
 
-    def _emitbuild(self, code):
-        fname = f"factory_{code.allocateId()}"
-        code.append(f"{fname} = {repr(self.encmapping)}")
-        return f"reuse({fname}[obj], lambda obj: ({self.subcon._compilebuild(code)}))"
+    def _emitencode(self, code):
+        return f"{_emit_source_or_use_linked(code, self.encmapping)}[obj]"
 
 
 #===============================================================================

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     },
     author = "Arkadiusz Bulski, Tomer Filiba, Corbin Simpson",
     author_email = "arek.bulski@gmail.com, tomerfiliba@gmail.com, MostAwesomeDude@gmail.com",
-    python_requires = ">=3.8",
+    python_requires = ">=3.9",
     install_requires = [],
     extras_require = {
         "extras": [

--- a/tests/declarativeunittest.py
+++ b/tests/declarativeunittest.py
@@ -20,7 +20,7 @@ def raises(func, *args, **kw):
     except Exception as e:
         return e.__class__
 
-def common(format, datasample, objsample, sizesample=SizeofError, **kw):
+def common(format, datasample, objsample, sizesample=SizeofError, compile=True, **kw):
     # following are implied (re-parse and re-build)
     # assert format.parse(format.build(obj)) == obj
     # assert format.build(format.parse(data)) == data
@@ -40,12 +40,13 @@ def common(format, datasample, objsample, sizesample=SizeofError, **kw):
     # following was added to test compiling functionality
     # and implies: format.parse(data) == cformat.parse(data)
     # and implies: format.build(obj) == cformat.build(obj)
-    cformat = format.compile()
-
-    obj = cformat.parse(datasample, **kw)
-    assert obj == objsample, f"{obj} != {objsample} (obj, compiled)"
-    data = cformat.build(objsample, **kw)
-    assert data == datasample, f"{data} != {datasample} (data, compiled)"
+    if compile:
+        cformat = format.compile()
+    
+        obj = cformat.parse(datasample, **kw)
+        assert obj == objsample, f"{obj} != {objsample} (obj, compiled)"
+        data = cformat.build(objsample, **kw)
+        assert data == datasample, f"{data} != {datasample} (data, compiled)"
 
 def commonhex(format, hexdata):
     commonbytes(format, binascii.unhexlify(hexdata))

--- a/tests/declarativeunittest.py
+++ b/tests/declarativeunittest.py
@@ -25,30 +25,27 @@ def common(format, datasample, objsample, sizesample=SizeofError, **kw):
     # assert format.parse(format.build(obj)) == obj
     # assert format.build(format.parse(data)) == data
     obj = format.parse(datasample, **kw)
-    assert obj == objsample
+    assert obj == objsample, f"{obj} != {objsample} (obj, non compiled)"
     data = format.build(objsample, **kw)
-    assert data == datasample
+    assert data == datasample, f"{data} != {datasample} (data, non compiled)"
 
     if isinstance(sizesample, int):
         size = format.sizeof(**kw)
-        assert size == sizesample
+        assert size == sizesample, f"{size} != {sizesample} (size (int), non compiled)"
     else:
         size = raises(format.sizeof, **kw)
-        assert size == sizesample
+        assert size == sizesample, f"{size} != {sizesample} (size, non compiled)"
 
     # attemps to compile, ignores if compilation fails
     # following was added to test compiling functionality
     # and implies: format.parse(data) == cformat.parse(data)
     # and implies: format.build(obj) == cformat.build(obj)
-    try:
-        cformat = format.compile()
-    except Exception:
-        pass
-    else:
-        obj = cformat.parse(datasample, **kw)
-        assert obj == objsample
-        data = cformat.build(objsample, **kw)
-        assert data == datasample
+    cformat = format.compile()
+
+    obj = cformat.parse(datasample, **kw)
+    assert obj == objsample, f"{obj} != {objsample} (obj, compiled)"
+    data = cformat.build(objsample, **kw)
+    assert data == datasample, f"{data} != {datasample} (data, compiled)"
 
 def commonhex(format, hexdata):
     commonbytes(format, binascii.unhexlify(hexdata))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1690,7 +1690,7 @@ def test_operators_issue_87():
 
 def test_from_issue_76():
     d = Aligned(4, Struct("a"/Byte, "f"/Bytes(lambda ctx: ctx.a)))
-    common(d, b"\x02\xab\xcd\x00", Container(a=2, f=b"\xab\xcd"))
+    common(d, b"\x02\xab\xcd\x00", Container(a=2, f=b"\xab\xcd"), compile=False)
 
 def test_from_issue_60():
     Header = Struct(
@@ -1973,21 +1973,21 @@ def test_exposing_members_context():
         "data" / Bytes(lambda this: this.count - this._subcons.count.sizeof()),
         Check(lambda this: this._subcons.count.sizeof() == 1),
     )
-    common(d, b"\x05four", Container(count=5, data=b"four"))
+    common(d, b"\x05four", Container(count=5, data=b"four"), compile=False)
 
     d = Sequence(
         "count" / Byte,
         "data" / Bytes(lambda this: this.count - this._subcons.count.sizeof()),
         Check(lambda this: this._subcons.count.sizeof() == 1),
     )
-    common(d, b"\x05four", [5,b"four",None])
+    common(d, b"\x05four", [5,b"four",None], compile=False)
 
     d = FocusedSeq("count",
         "count" / Byte,
         "data" / Padding(lambda this: this.count - this._subcons.count.sizeof()),
         Check(lambda this: this._subcons.count.sizeof() == 1),
     )
-    common(d, b'\x04\x00\x00\x00', 4, SizeofError)
+    common(d, b'\x04\x00\x00\x00', 4, SizeofError, compile=False)
 
     d = Union(None,
         "chars" / Byte[4],
@@ -2366,9 +2366,9 @@ def test_switch_issue_913_using_enum():
     }
 
     d = Switch(keyfunc = this.x, cases = mapping)
-    common(d, b"", None, 0, x="Zero")
-    common(d, b"\xab", 171, 1, x="One")
-    common(d, b"\x09\x00", 9, 2, x="Two")
+    common(d, b"", None, 0, x=enum.Zero)
+    common(d, b"\xab", 171, 1, x=enum.One)
+    common(d, b"\x09\x00", 9, 2, x=enum.Two)
 
 def test_switch_issue_913_using_strings():
     mapping = {


### PR DESCRIPTION
This is a reasonably sized Pull request, addressing these topics.:

1. Tests used to pass when attempts to compile threw an exception -> now they fail
 - a view tests are now marked that they shall not try to compiles, these have "dynamic" structures.
2. repr sometimes yields a string which can not be parsed -> _emit_source_or_use_linked checks if repr works, and uses userfunction if it does not
3. almost all compile errors where due to lambdas not being allowed in places -> now they are allowed everywhere

There is a user visible change, it is no longer possible to use strings for switches which use enums as a key datatype.

Python 3.13 was added, 3.8 removed
 