### PR TITLE
fixes issue 1082

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -238,9 +238,12 @@ def stream_iseof(stream):
 class BytesIOWithOffsets(io.BytesIO):
     @staticmethod
     def from_reading(stream, length: int, path: str):
-        offset = stream_tell(stream, path)
-        contents = stream_read(stream, length, path)
-        return BytesIOWithOffsets(contents, stream, offset)
+        try:
+            offset = stream_tell(stream, path)
+            contents = stream_read(stream, length, path)
+            return BytesIOWithOffsets(contents, stream, offset)
+        except io.UnsupportedOperation:
+            return io.BytesIO(stream_read(stream, length, path))
 
     def __init__(self, contents: bytes, parent_stream, offset: int):
         super().__init__(contents)

--- a/construct/core.py
+++ b/construct/core.py
@@ -242,7 +242,7 @@ class BytesIOWithOffsets(io.BytesIO):
             offset = stream_tell(stream, path)
             contents = stream_read(stream, length, path)
             return BytesIOWithOffsets(contents, stream, offset)
-        except io.UnsupportedOperation:
+        except (io.UnsupportedOperation, StreamError):
             return io.BytesIO(stream_read(stream, length, path))
 
     def __init__(self, contents: bytes, parent_stream, offset: int):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2458,7 +2458,7 @@ def test_issue_1082():
             of.write(b"\x01\x02")
         d = Prefixed(Int8ub, Byte)
         outPuter = {"Linux": "cat", "Windows": "type"}[platform.system()]
-        pid = subprocess.Popen([outPuter, oFileName], stdout=subprocess.PIPE)
+        pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
         assert 2 == d.parse_stream(pid.stdout)
-        pid = subprocess.Popen([outPuter, oFileName], stdout=subprocess.PIPE)
+        pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
         assert 2 == d.compile().parse_stream(pid.stdout)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import subprocess
+import tempfile
 from tests.declarativeunittest import *
 from construct import *
 from construct.lib import *
@@ -2447,3 +2449,14 @@ def test_issue_1014():
         )),
     )
     assert d.parse(bytes([1,2,3,4,5,6])) == Container(version=0x0102, box=Container(position=3, payload=b'\x04\x05\x06'))
+
+def test_issue_1082():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        oFileName = tmpdir + "blob"
+        with open(oFileName, "wb") as of:
+            of.write(b"\x01\x02")
+        d = Prefixed(Int8ub, Byte)
+        pid = subprocess.Popen(["cat", oFileName], stdout=subprocess.PIPE)
+        assert 2 == d.parse_stream(pid.stdout)
+        pid = subprocess.Popen(["cat", oFileName], stdout=subprocess.PIPE)
+        assert 2 == d.compile().parse_stream(pid.stdout)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import platform
 import subprocess
 import tempfile
 from tests.declarativeunittest import *
@@ -2456,7 +2457,8 @@ def test_issue_1082():
         with open(oFileName, "wb") as of:
             of.write(b"\x01\x02")
         d = Prefixed(Int8ub, Byte)
-        pid = subprocess.Popen(["cat", oFileName], stdout=subprocess.PIPE)
+        outPuter = {"Linux": "cat", "Windows": "type"}[platform.system()]
+        pid = subprocess.Popen([outPuter, oFileName], stdout=subprocess.PIPE)
         assert 2 == d.parse_stream(pid.stdout)
-        pid = subprocess.Popen(["cat", oFileName], stdout=subprocess.PIPE)
+        pid = subprocess.Popen([outPuter, oFileName], stdout=subprocess.PIPE)
         assert 2 == d.compile().parse_stream(pid.stdout)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2454,11 +2454,13 @@ def test_issue_1014():
 def test_issue_1082():
     with tempfile.TemporaryDirectory() as tmpdir:
         oFileName = tmpdir + "blob"
-        with open(oFileName, "wb") as of:
-            of.write(b"\x01\x02")
-        d = Prefixed(Int8ub, Byte)
         outPuter = {"Linux": "cat", "Windows": "type"}[platform.system()]
-        pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
-        assert 2 == d.parse_stream(pid.stdout)
-        pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
-        assert 2 == d.compile().parse_stream(pid.stdout)
+        with open(oFileName, "wb") as of:
+            of.write(b"\x02\x02\x00")
+
+        for d in [Prefixed(Int8ub, Byte), FixedSized(2, Byte)]:
+            pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
+            assert 2 == d.parse_stream(pid.stdout)
+            pid = subprocess.Popen(f"{outPuter} {oFileName}", stdout=subprocess.PIPE, shell=True)
+            assert 2 == d.compile().parse_stream(pid.stdout)
+


### PR DESCRIPTION
This PR brings a new test case which test Prefixed and FixedSize constructs using system.Popen to create non tellable streams, and then tests if these streams can be parsed.

AND a fix to make this actually work