### PR TITLE
Allow for interpreting the Pointer offset as relative

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -969,6 +969,27 @@ def test_pointer():
     )
     assert d.parse(bytes(20)) == Container(inner=Container(), x=0)
 
+    d = Struct (
+        'dummy' / Byte,
+        'pointer' / Pointer(1, Byte, relativeOffset=True),
+    )
+
+    common(d, b"\xde\x00\xad", Container(dummy=0xde, pointer=0xad), 1)
+
+    d = Struct (
+        'dummy' / Byte,
+        'pointer' / Pointer(0, Byte, relativeOffset=True),
+    )
+
+    common(d, b"\xde\xad", Container(dummy=0xde, pointer=0xad), 1)
+
+    d = Struct (
+        'dummy' / Byte,
+        'pointer' / Pointer(-1, Byte, relativeOffset=True),
+    )
+
+    common(d, b"\xde", Container(dummy=0xde, pointer=0xde), 1)
+
 def test_peek():
     d = Peek(Int8ub)
     assert d.parse(b"\x01") == 1


### PR DESCRIPTION
This PR adds a new keyword argument called `relativeOffset` to the `Pointer` subconstruct which causes the offset to be interpreted as being relative to the current stream position.

This is quite useful in certain situations, as shown in #1112.

I tried my best regarding `_emitparse` and `_emitbuild`, but i would be very happy if someone knowledgeable would take a look at it.

Thanks,
Armin Wolf