### PR TITLE
Add return type annotation for Construct.sizeof

### DIFF
--- a/construct/core.py
+++ b/construct/core.py
@@ -478,7 +478,7 @@ class Construct(object):
         """Override in your subclass."""
         raise NotImplementedError
 
-    def sizeof(self, **contextkw):
+    def sizeof(self, **contextkw) -> int:
         r"""
         Calculate the size of this object, optionally using a context.
 


### PR DESCRIPTION
The default implementation of `Construct.sizeof` unconditionally raises a `SizeofError`, because it is meant to be overridden in subclasses. This confuses some type checkers (e.g., pyright) which incorrectly (from construct's point-of-view) infer `Construct.sizeof` to not return, assigning it the `NoReturn` return type.

Explicitly set the return type hint for `Construct.sizeof` to `int`, so that pyright correctly deals with this function.